### PR TITLE
[Proposal] Add source -> rev mapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ plugin.map = {};
 plugin.save = function(fileName){
 	fs.writeFile(fileName, JSON.stringify(plugin.map), function (err) {
 	  if (err) throw err;
+	  gutil.log('gulp-rev: Saved map to ' + gutil.colors.green(fileName));
 	});
 }
 module.exports = plugin;


### PR DESCRIPTION
As proposed in #2, this saves the hashes in memory and adds a save() function. This way you can call rev.save('map.json') in a task, to save the mappings to a file.
(But this is the first ever node.js thing I wrote and just started using Gulp, so there are probably better ways to do this)

As described, the intended purpose of this file in my case is to let my framework (php) replace the links, based on the mapping.

The save function could maybe be left out and just leave that to the user, who can retrieve rev.map.
