### PR TITLE
add option for user to customize file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function relPath(base, filePath) {
 	}
 }
 
-var plugin = function () {
+var plugin = function (options) {
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			this.push(file);
@@ -32,13 +32,16 @@ var plugin = function () {
 			return cb();
 		}
 
+		options = options || {};
+		var format = options.format || '{name}-{hash}.{ext}';
+
 		// save the old path for later
 		file.revOrigPath = file.path;
 		file.revOrigBase = file.base;
 
 		var hash = md5(file.contents.toString()).slice(0, 8);
 		var ext = path.extname(file.path);
-		var filename = path.basename(file.path, ext) + '-' + hash + ext;
+		var filename = format.replace('{name}', path.basename(file.path, ext)).replace('{hash}', hash).replace('{ext}', ext.substring(1));
 		file.path = path.join(path.dirname(file.path), filename);
 		this.push(file);
 		cb();

--- a/test.js
+++ b/test.js
@@ -19,6 +19,21 @@ it('should rev files', function (cb) {
 	}));
 });
 
+it('should respect file format', function (cb) {
+	var stream = rev({format: '{name}.v{hash}.{ext}'});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn.vd41d8cd9.css');
+		assert.equal(file.revOrigPath, 'unicorn.css');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css',
+		contents: new Buffer('')
+	}));
+});
+
 it('should build a rev manifest file', function (cb) {
 	var stream = rev.manifest();
 


### PR DESCRIPTION
I like the simplicity of this gulp plugin, but I cannot customize the revisioned file path, so I added an option for that purpose.

usage:

```
gulp.src(SRC)
    .pipe(rev({ format: '{name}.v{hash}.{ext}'}))
    .pipe(gulp.dest(DEST));
```

the default naming format is respected, I also added test case for this modification
