### PR TITLE
Do not convert file contents to strings before hashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ plugin.manifest = function () {
 		// ignore all non-rev'd files
 		if (file.path && file.revOrigPath) {
 			firstFile = firstFile || file;
-			manifest[relPath(firstFile.revOrigBase, file.revOrigPath)] = relPath(firstFile.base, file.path);
+			manifest[relPath(file.revOrigBase, file.revOrigPath)] = relPath(file.base, file.path);
 		}
 
 		cb();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-rev",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Static asset revisioning by appending content hash to filenames: unicorn.css => unicorn-098f6bcd.css",
   "license": "MIT",
   "repository": "sindresorhus/gulp-rev",


### PR DESCRIPTION
This makes the md5 hash compatible with most other tools (Rails, Compass, the `md5` command, etc.).
