### PR TITLE
Do not convert file contents to strings before hashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 
 function md5(str) {
-	return crypto.createHash('md5').update(str, 'utf8').digest('hex');
+	return crypto.createHash('md5').update(str).digest('hex');
 }
 
 function relPath(base, filePath) {
@@ -31,7 +31,7 @@ var plugin = function () {
 		file.revOrigPath = file.path;
 		file.revOrigBase = file.base;
 
-		var hash = file.revHash = md5(file.contents.toString()).slice(0, 8);
+		var hash = file.revHash = md5(file.contents).slice(0, 8);
 		var ext = path.extname(file.path);
 		var filename = path.basename(file.path, ext) + '-' + hash + ext;
 		file.path = path.join(path.dirname(file.path), filename);


### PR DESCRIPTION
This makes the md5 hash compatible with most other tools (Rails, Compass, the `md5` command, etc.).
