### PR TITLE
Remove Absolute Paths from Manifest from Multiple Directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ plugin.manifest = function () {
 		// ignore all non-rev'd files
 		if (file.path && file.revOrigPath) {
 			firstFile = firstFile || file;
-			manifest[relPath(firstFile.revOrigBase, file.revOrigPath)] = relPath(firstFile.base, file.path);
+			manifest[relPath(file.revOrigBase, file.revOrigPath)] = relPath(file.revOrigBase, file.path);
 		}
 
 		cb();


### PR DESCRIPTION
- Files from multiple directories did not properly remove the absolute
  path.
- Removes absolute path when using files from multiple directories.
- Corrects test spec to use proper `base`.

For example, when using files from `public/assets` and  `public/images` (in order), files copied from `public/images` would have the absolute path.
