### PR TITLE
Combine Previous Manifest with Current

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var crypto = require('crypto');
 var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
+var objectAssign = require('object-assign');
 
 function md5(str) {
 	return crypto.createHash('md5').update(str).digest('hex');
@@ -45,13 +46,24 @@ var plugin = function () {
 	});
 };
 
-plugin.manifest = function () {
+plugin.manifest = function (opt) {
+	opt = objectAssign({path: 'rev-manifest.json'}, opt || {});
 	var manifest  = {};
 	var firstFile = null;
 
 	return through.obj(function (file, enc, cb) {
 		// ignore all non-rev'd files
-		if (file.path && file.revOrigPath) {
+		if (!file.path || !file.revOrigPath) {
+			cb();
+			return;
+		}
+
+		// Combine previous manifest. Only add if key isn't already there.
+		if (opt.path == file.revOrigPath) {
+			var existingManifest = JSON.parse(file.contents.toString());
+			manifest = objectAssign(existingManifest, manifest);
+		// Add file to manifest
+		} else {
 			firstFile = firstFile || file;
 			manifest[relPath(firstFile.revOrigBase, file.revOrigPath)] = relPath(firstFile.base, file.path);
 		}
@@ -62,7 +74,7 @@ plugin.manifest = function () {
 			this.push(new gutil.File({
 				cwd: firstFile.cwd,
 				base: firstFile.base,
-				path: path.join(firstFile.base, 'rev-manifest.json'),
+				path: path.join(firstFile.base, opt.path),
 				contents: new Buffer(JSON.stringify(manifest, null, '  '))
 			}));
 		}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
+    "object-assign": "^1.0.0",
     "through2": "~0.5.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,31 @@ An asset manifest, mapping the original paths to the revisioned paths, will be w
 }
 ```
 
+By default, `rev-manifest.json` will be replaced as a whole. For modifications, add `rev-manifest.json` as a gulp source:
+
+```js
+var gulp = require('gulp');
+var rev = require('gulp-rev');
+
+gulp.task('default', function () {
+	// by default, gulp would pick `assets/css` as the base,
+	// so we need to set it explicitly:
+	return gulp.src([
+		'assets/css/*.css',
+		'assets/js/*.js'
+	], {base: 'assets'})
+		.pipe(gulp.dest('build/assets'))
+		.pipe(rev())
+		.pipe(gulp.dest('build/assets'))
+
+		// Add rev-manifest.json as a new src to prevent rev'ing rev-manifest.json
+		.pipe(gulp.src('build/assets/rev-manifest.json', {base: 'assets'}))
+		.pipe(rev.manifest())             // applies only changes to the manifest
+		.pipe(gulp.dest('build/assets'));
+});
+```
+
+You can optionally call `rev.manifest({path: 'manifest.json'})` to give it a different path or filename.
 
 ### Streaming
 

--- a/test.js
+++ b/test.js
@@ -42,6 +42,54 @@ it('should build a rev manifest file', function (cb) {
 	stream.end();
 });
 
+it('should allow naming the manifest file', function (cb) {
+	var path = 'manifest.json';
+	var stream = rev.manifest({path: path});
+
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.relative, path);
+		cb();
+	});
+
+	var file = new gutil.File({
+		path: 'unicorn-d41d8cd9.css',
+		contents: new Buffer('')
+	});
+	file.revOrigPath = 'unicorn.css';
+
+	stream.write(file);
+	stream.end();
+});
+
+it('should append to an existing rev manifest file', function (cb) {
+	var stream = rev.manifest();
+
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.relative, 'rev-manifest.json');
+		assert.deepEqual(
+			JSON.parse(newFile.contents.toString()),
+			{'app.js': 'app-a41d8cd1.js', 'unicorn.css': 'unicorn-d41d8cd9.css'}
+		);
+		cb();
+	});
+
+	var mFile = new gutil.File({
+		path: 'rev-manifest.json',
+		contents: new Buffer('{ "app.js": "app-a41d8cd1.js", "unicorn.css": "unicorn-b41d8cd2.css" }')
+	});
+	mFile.revOrigPath = 'rev-manifest.json';
+
+	var file = new gutil.File({
+		path: 'unicorn-d41d8cd9.css',
+		contents: new Buffer('')
+	});
+
+	file.revOrigPath = 'unicorn.css';
+
+	stream.write(mFile);
+	stream.write(file);
+	stream.end();
+});
 
 it('should respect directories', function (cb) {
 	var stream = rev.manifest();


### PR DESCRIPTION
- When `rev-manifest.json` is included in `gulp.src`, the old manifest
  will be used to preserve data. This allows separate gulp tasks to
  use the same manifest.
- Optionally supply a file name to `rev.manifest`. Defaults to
  'rev-manifest.json'. Example: `rev.manifest({ name: 'manifest.json'
  });
