### PR TITLE
Fix appending to an existing rev-manifest.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,14 +52,16 @@ plugin.manifest = function (opt) {
 	var firstFile = null;
 
 	return through.obj(function (file, enc, cb) {
+		var fileIsManifest = (new RegExp(opt.path + '$')).test(file.path);
+
 		// ignore all non-rev'd files
-		if (!file.path || !file.revOrigPath) {
+		if ((!file.path || !file.revOrigPath) && !fileIsManifest) {
 			cb();
 			return;
 		}
 
 		// Combine previous manifest. Only add if key isn't already there.
-		if (opt.path == file.revOrigPath) {
+		if (fileIsManifest) {
 			var existingManifest = JSON.parse(file.contents.toString());
 			manifest = objectAssign(existingManifest, manifest);
 		// Add file to manifest

--- a/readme.md
+++ b/readme.md
@@ -66,26 +66,29 @@ An asset manifest, mapping the original paths to the revisioned paths, will be w
 }
 ```
 
-By default, `rev-manifest.json` will be replaced as a whole. For modifications, add `rev-manifest.json` as a gulp source:
+By default, `rev-manifest.json` will be replaced as a whole. For modifications, add `rev-manifest.json` as a gulp source using `event-stream`:
 
 ```js
 var gulp = require('gulp');
 var rev = require('gulp-rev');
+var es = require('event-stream');
 
 gulp.task('default', function () {
 	// by default, gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
-	return gulp.src([
+	var assets = gulp.src([
 		'assets/css/*.css',
 		'assets/js/*.js'
 	], {base: 'assets'})
 		.pipe(gulp.dest('build/assets'))
 		.pipe(rev())
-		.pipe(gulp.dest('build/assets'))
+		.pipe(gulp.dest('build/assets'));
 
-		// Add rev-manifest.json as a new src to prevent rev'ing rev-manifest.json
-		.pipe(gulp.src('build/assets/rev-manifest.json', {base: 'assets'}))
-		.pipe(rev.manifest())             // applies only changes to the manifest
+	// Add rev-manifest.json as a new src to prevent rev'ing rev-manifest.json
+	var manifest = gulp.src('build/assets/rev-manifest.json', {base: 'assets'});
+
+	return es.merge(assets, manifest)
+		.pipe(rev.manifest()) // applies only changes to the manifest
 		.pipe(gulp.dest('build/assets'));
 });
 ```


### PR DESCRIPTION
- Use a regex to compare the file path to the name to determine if the
  file is the existing manifest.
- `file.path` is the full, absolute path, which did not match a source
  given in gulp.
- Update `readme.md` to use `event-stream`.

- Fixes #55