### PR TITLE
All OS's should use the same path separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function md5(str) {
 
 function relPath(base, filePath) {
 	if (filePath.indexOf(base) !== 0) {
-		return filePath;
+		return filePath.replace(/\\/g, '/');
 	}
 	var newPath = filePath.substr(base.length).replace(/\\/g, '/');
 	if (newPath[0] === '/') {


### PR DESCRIPTION
Path need to be consistence across all OS's. As it was before, when using this on Windows, path separator would be a backslash `\` while all other OS's would use `/`. Windows can read `/` as a directory separator so this won't be a problem. A standard `/`-separator will allow us to get the key with a standard syntax without some extra hack.

**Running gulp-rev from a Windows machine**
With this change, the `rev-manifest.json` file would be like this (same as other Linux/Unix distros):

```
{
  "css/bootstrap.css": "css/bootstrap-12eb57ae.css"
}
```

Without my change, it would be like this (**different** from other Linux/Unix distros):

```
{
  "css\\bootstrap.css": "css\\bootstrap-12eb57ae.css"
}
```
