### PR TITLE
load existing manifest directly from file and fix appending

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 var objectAssign = require('object-assign');
+var file = require('vinyl-file');
 
 function md5(str) {
 	return crypto.createHash('md5').update(str).digest('hex');
@@ -23,6 +24,19 @@ function relPath(base, filePath) {
 	return newPath;
 }
 
+function readExistingManifestFile(pth, opt) {
+	try {
+		return file.readSync(path.join(opt.base, pth), opt);
+	}
+	catch (e) {
+		// no existing manifest found at path.join(opt.base, pth)
+		return new gutil.File({
+			cwd: opt.cwd,
+			base: opt.base,
+			path: path.join(opt.base, pth)
+		});
+	}
+}
 var plugin = function () {
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -48,9 +62,11 @@ var plugin = function () {
 };
 
 plugin.manifest = function (opt) {
-	opt = objectAssign({path: 'rev-manifest.json'}, opt || {});
-	var manifest = {};
+	opt = objectAssign({path: 'rev-manifest.json', base: '.'}, opt || {});
 	var firstFile = null;
+
+	var manifestFile = readExistingManifestFile(opt.path, opt);
+	var manifest = manifestFile.isNull() ? {} : JSON.parse(manifestFile.contents.toString());
 
 	return through.obj(function (file, enc, cb) {
 		// ignore all non-rev'd files
@@ -61,6 +77,7 @@ plugin.manifest = function (opt) {
 
 		// combine previous manifest
 		// only add if key isn't already there
+		// this is used, if the manifest file is part of the stream.
 		if (opt.path == file.revOrigPath) {
 			var existingManifest = JSON.parse(file.contents.toString());
 			manifest = objectAssign(existingManifest, manifest);
@@ -73,12 +90,8 @@ plugin.manifest = function (opt) {
 		cb();
 	}, function (cb) {
 		if (firstFile) {
-			this.push(new gutil.File({
-				cwd: firstFile.cwd,
-				base: firstFile.base,
-				path: path.join(firstFile.base, opt.path),
-				contents: new Buffer(JSON.stringify(manifest, null, '  '))
-			}));
+			manifestFile.contents = new Buffer(JSON.stringify(manifest, null, '  '));
+			this.push(manifestFile);
 		}
 
 		cb();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "object-assign": "^1.0.0",
-    "through2": "^0.6.1"
+    "through2": "^0.6.1",
+    "vinyl-file": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ An asset manifest, mapping the original paths to the revisioned paths, will be w
 }
 ```
 
-By default, `rev-manifest.json` will be replaced as a whole. For modifications, add `rev-manifest.json` as a gulp source:
+By default, `rev-manifest.json` will be replaced as a whole. For modifications, use optional options to rev.manifest():
 
 ```js
 var gulp = require('gulp');
@@ -82,10 +82,7 @@ gulp.task('default', function () {
 		.pipe(gulp.dest('build/assets'))
 		.pipe(rev())
 		.pipe(gulp.dest('build/assets'))
-
-		// Add rev-manifest.json as a new src to prevent rev'ing rev-manifest.json
-		.pipe(gulp.src('build/assets/rev-manifest.json', {base: 'assets'}))
-		.pipe(rev.manifest())             // applies only changes to the manifest
+		.pipe(rev.manifest({base: 'build/assets', appendExisting: true))     // applies only changes to the manifest
 		.pipe(gulp.dest('build/assets'));
 });
 ```

--- a/test.js
+++ b/test.js
@@ -61,7 +61,7 @@ it('should allow naming the manifest file', function (cb) {
 	stream.end();
 });
 
-it('should append to an existing rev manifest file', function (cb) {
+it('should append to an existing rev manifest file (from stream)', function (cb) {
 	var stream = rev.manifest();
 
 	stream.on('data', function (newFile) {
@@ -89,6 +89,30 @@ it('should append to an existing rev manifest file', function (cb) {
 	stream.write(mFile);
 	stream.write(file);
 	stream.end();
+});
+
+it('should append to an existing rev manifest file (from file)', function (cb) {
+	var stream = rev.manifest({path: 'test.manifest-fixture.json'});
+
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.relative, 'test.manifest-fixture.json');
+		assert.deepEqual(
+			JSON.parse(newFile.contents.toString()),
+			{'app.js': 'app-a41d8cd1.js', 'unicorn.css': 'unicorn-d41d8cd9.css'}
+		);
+		cb();
+	});
+
+	var file = new gutil.File({
+		path: 'unicorn-d41d8cd9.css',
+		contents: new Buffer('')
+	});
+
+	file.revOrigPath = 'unicorn.css';
+
+	stream.write(file);
+	stream.end();
+
 });
 
 it('should respect directories', function (cb) {

--- a/test.js
+++ b/test.js
@@ -61,23 +61,17 @@ it('should allow naming the manifest file', function (cb) {
 	stream.end();
 });
 
-it('should append to an existing rev manifest file (from stream)', function (cb) {
-	var stream = rev.manifest();
+it('should append to an existing rev manifest file', function (cb) {
+	var stream = rev.manifest({path: 'test.manifest-fixture.json', appendExisting: true});
 
 	stream.on('data', function (newFile) {
-		assert.equal(newFile.relative, 'rev-manifest.json');
+		assert.equal(newFile.relative, 'test.manifest-fixture.json');
 		assert.deepEqual(
 			JSON.parse(newFile.contents.toString()),
 			{'app.js': 'app-a41d8cd1.js', 'unicorn.css': 'unicorn-d41d8cd9.css'}
 		);
 		cb();
 	});
-
-	var mFile = new gutil.File({
-		path: 'rev-manifest.json',
-		contents: new Buffer('{ "app.js": "app-a41d8cd1.js", "unicorn.css": "unicorn-b41d8cd2.css" }')
-	});
-	mFile.revOrigPath = 'rev-manifest.json';
 
 	var file = new gutil.File({
 		path: 'unicorn-d41d8cd9.css',
@@ -86,19 +80,19 @@ it('should append to an existing rev manifest file (from stream)', function (cb)
 
 	file.revOrigPath = 'unicorn.css';
 
-	stream.write(mFile);
 	stream.write(file);
 	stream.end();
+
 });
 
-it('should append to an existing rev manifest file (from file)', function (cb) {
+it('should not append to an existing rev manifest by default', function (cb) {
 	var stream = rev.manifest({path: 'test.manifest-fixture.json'});
 
 	stream.on('data', function (newFile) {
 		assert.equal(newFile.relative, 'test.manifest-fixture.json');
 		assert.deepEqual(
 			JSON.parse(newFile.contents.toString()),
-			{'app.js': 'app-a41d8cd1.js', 'unicorn.css': 'unicorn-d41d8cd9.css'}
+			{'unicorn.css': 'unicorn-d41d8cd9.css'}
 		);
 		cb();
 	});

--- a/test.manifest-fixture.json
+++ b/test.manifest-fixture.json
@@ -1,0 +1,1 @@
+{ "app.js": "app-a41d8cd1.js", "unicorn.css": "unicorn-b41d8cd2.css" }


### PR DESCRIPTION
this fixes #65, #60, #59 and #55.

This change reads an existing rev-manifest file as part of the rev.manifest() call instead of injecting the existing manifest file into the stream of asset files.
to keep the default behaviour, there is a new boolean option `appendExisting`. the usage looks like:
```
return gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
	.pipe(gulp.dest('build/assets'))
	.pipe(rev())
	.pipe(gulp.dest('build/assets'))
	.pipe(rev.manifest({base: 'build/assets', appendExisting: true))     //base is the folder to read from
	.pipe(gulp.dest('build/assets'));
```

my goal was to simplify the usage, fix the existing bugs and make it easier to read/maintain.
