### PR TITLE
support gulp-sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ var plugin = function () {
 			return;
 		}
 
-		if (path.extname(file.path) == '.map') {
+		if (path.extname(file.path) === '.map') {
 			// This is a sourcemap, hold until the end
 			sourcemaps.push(file);
 			cb();

--- a/readme.md
+++ b/readme.md
@@ -133,9 +133,9 @@ gulp.task('default', function () {
 	return gulp.src('src/*.js') 
 		.pipe(sourcemaps.init())
 		.pipe(concat({ path: 'bundle.js', cwd: ''}))
-		.pipe(sourcemaps.write())
 		.pipe(rev())
-		.pipe(gulp.dest('dist'))
+		.pipe(sourcemaps.write('.'))
+		.pipe(gulp.dest('dist'));
 
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,27 @@ gulp.task('default', function () {
 For more info on how to integrate **gulp-rev** into your app, have a look at the [integration guide](integration.md).
 
 
+### Sourcemaps and `gulp-concat`
+
+Because of the way `gulp-concat` handles file paths, you may need to set `cwd` and `path` manually on your `gulp-concat` instance to get everything to work correctly:
+
+```js
+var gulp = require('gulp');
+var rev = require('gulp-rev');
+var sourcemaps = require('gulp-sourcemaps');
+var concat = require('gulp-concat');
+
+gulp.task('default', function () {
+	return gulp.src('src/*.js') 
+		.pipe(sourcemaps.init())
+		.pipe(concat({ path: 'bundle.js', cwd: ''}))
+		.pipe(sourcemaps.write())
+		.pipe(rev())
+		.pipe(gulp.dest('dist'))
+
+```
+
+
 ### Works with gulp-rev
 
 - [gulp-rev-replace](https://github.com/jamesknelson/gulp-rev-replace)

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,27 @@ gulp.task('default', function () {
 });
 ```
 
-*Options are intentionally missing as the default should work in most cases.*
+With `gulp-sourcemaps`:
 
+```js
+var gulp = require('gulp');
+var rev = require('gulp-rev');
+var sourcemaps = require('gulp-sourcemaps');
+
+gulp.task('default', function () {
+	return gulp.src('src/*.js')
+		.pipe(sourcemaps.init())
+		.pipe(gulp.concat('app.js'))
+		.pipe(sourcemaps.write('./maps'))
+		.pipe(rev({sourcemapDestPath: './maps'}))
+		.pipe(gulp.dest('dist'));
+});
+
+```
+
+### Options
+
+- `sourcemapDestPath`: if you're using `gulp-sourcemaps` with external source maps, supply the path from `sourcemaps.write()` here.
 
 ### Original path
 

--- a/readme.md
+++ b/readme.md
@@ -26,27 +26,8 @@ gulp.task('default', function () {
 });
 ```
 
-With `gulp-sourcemaps`:
+*Options are intentionally missing as the default should work in most cases.*
 
-```js
-var gulp = require('gulp');
-var rev = require('gulp-rev');
-var sourcemaps = require('gulp-sourcemaps');
-
-gulp.task('default', function () {
-	return gulp.src('src/*.js')
-		.pipe(sourcemaps.init())
-		.pipe(gulp.concat('app.js'))
-		.pipe(sourcemaps.write('./maps'))
-		.pipe(rev({sourcemapDestPath: './maps'}))
-		.pipe(gulp.dest('dist'));
-});
-
-```
-
-### Options
-
-- `sourcemapDestPath`: if you're using `gulp-sourcemaps` with external source maps, supply the path from `sourcemaps.write()` here.
 
 ### Original path
 

--- a/test.js
+++ b/test.js
@@ -155,30 +155,6 @@ it('should handle sourcemaps transparently', function(cb) {
 
 	stream.on('data', function (file) {
 		if (path.extname(file.path) === '.map') {
-			assert.equal(file.path, 'pastissada-d41d8cd9.css.map');
-			cb();
-		}
-	});
-
-	stream.write(new gutil.File({
-		path: 'pastissada.css',
-		contents: new Buffer('')
-	}));
-
-	stream.end(new gutil.File({
-		path: 'pastissada.css.map',
-		contents: new Buffer('delicious')
-	}));
-
-
-});
-
-it('should use the sourcemapDestPath parameter correctly', function(cb) {
-
-	var stream = rev({sourcemapDestPath: 'maps'});
-
-	stream.on('data', function (file) {
-		if (path.extname(file.path) === '.map') {
 			assert.equal(file.path, 'maps/pastissada-d41d8cd9.css.map');
 			cb();
 		}
@@ -191,7 +167,54 @@ it('should use the sourcemapDestPath parameter correctly', function(cb) {
 
 	stream.end(new gutil.File({
 		path: 'maps/pastissada.css.map',
-		contents: new Buffer('delicious')
+		contents: new Buffer(JSON.stringify({ file: 'pastissada.css' }))
+	}));
+
+
+});
+
+it('should handle unparseable sourcemaps correctly', function(cb) {
+
+	var stream = rev();
+
+	stream.on('data', function (file) {
+		if (path.extname(file.path) === '.map') {
+			assert.equal(file.path, 'pastissada-d41d8cd9.css.map');
+			cb();
+		}
+	});
+
+	stream.write(new gutil.File({
+		path: 'pastissada.css',
+		contents: new Buffer('')
+	}));
+
+	stream.end(new gutil.File({
+		path: 'pastissada.css.map',
+		contents: new Buffer('Wait a minute, this is invalid JSON!')
+	}));
+
+});
+
+it('should be okay when the optional sourcemap.file is not defined', function(cb) {
+
+	var stream = rev();
+
+	stream.on('data', function (file) {
+		if (path.extname(file.path) === '.map') {
+			assert.equal(file.path, 'pastissada-d41d8cd9.css.map');
+			cb();
+		}
+	});
+
+	stream.write(new gutil.File({
+		path: 'pastissada.css',
+		contents: new Buffer('')
+	}));
+
+	stream.end(new gutil.File({
+		path: 'pastissada.css.map',
+		contents: new Buffer(JSON.stringify({}))
 	}));
 
 });

--- a/test.js
+++ b/test.js
@@ -148,3 +148,50 @@ it('should store the hashes for later', function (cb) {
 		contents: new Buffer('')
 	}));
 });
+
+it('should handle sourcemaps transparently', function(cb) {
+
+	var stream = rev();
+
+	stream.on('data', function (file) {
+		if (path.extname(file.path) === '.map') {
+			assert.equal(file.path, 'pastissada-d41d8cd9.css.map');
+			cb();
+		}
+	});
+
+	stream.write(new gutil.File({
+		path: 'pastissada.css',
+		contents: new Buffer('')
+	}));
+
+	stream.end(new gutil.File({
+		path: 'pastissada.css.map',
+		contents: new Buffer('delicious')
+	}));
+
+
+});
+
+it('should use the sourcemapDestPath parameter correctly', function(cb) {
+
+	var stream = rev({sourcemapDestPath: 'maps'});
+
+	stream.on('data', function (file) {
+		if (path.extname(file.path) === '.map') {
+			assert.equal(file.path, 'maps/pastissada-d41d8cd9.css.map');
+			cb();
+		}
+	});
+
+	stream.write(new gutil.File({
+		path: 'pastissada.css',
+		contents: new Buffer('')
+	}));
+
+	stream.end(new gutil.File({
+		path: 'maps/pastissada.css.map',
+		contents: new Buffer('delicious')
+	}));
+
+});


### PR DESCRIPTION
This pull request adds support for `gulp-sourcemaps`. It holds on to sourcemaps (i.e. files ending in `.map`) until the flush phase, where it checks to see if there's an associated source file. If there is, it uses the source file's hash; if not, it generates a new hash for the file as usual.

Tests and documentation are also updated.