### PR TITLE
Support customize hash method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,6 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var objectAssign = require('object-assign');
 
-function md5(str) {
-	return crypto.createHash('md5').update(str).digest('hex');
-}
 
 function relPath(base, filePath) {
 	if (filePath.indexOf(base) !== 0) {
@@ -23,7 +20,14 @@ function relPath(base, filePath) {
 	return newPath;
 }
 
-var plugin = function () {
+var plugin = function (opt) {
+	opt = opt || {};
+	opt.hashMethod = opt.hashMethod || 'md5';
+
+	var digest =  function(str) {
+		return crypto.createHash(opt.hashMethod).update(str).digest('hex');
+	}
+
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			cb(null, file);
@@ -39,7 +43,8 @@ var plugin = function () {
 		file.revOrigPath = file.path;
 		file.revOrigBase = file.base;
 
-		var hash = file.revHash = md5(file.contents).slice(0, 8);
+		var hash = file.revHash = digest(file.contents).slice(0, 8);
+		file.revHashMethod = opt.hashMethod;
 		var ext = path.extname(file.path);
 		var filename = path.basename(file.path, ext) + '-' + hash + ext;
 		file.path = path.join(path.dirname(file.path), filename);

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var plugin = function (opt) {
 
 	var digest =  function(str) {
 		return crypto.createHash(opt.hashMethod).update(str).digest('hex');
-	}
+	};
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {

--- a/test.js
+++ b/test.js
@@ -4,12 +4,13 @@ var assert = require('assert');
 var gutil = require('gulp-util');
 var rev = require('./');
 
-it('should rev files', function (cb) {
+it('should md5 rev files', function (cb) {
 	var stream = rev();
 
 	stream.on('data', function (file) {
 		assert.equal(file.path, 'unicorn-d41d8cd9.css');
 		assert.equal(file.revOrigPath, 'unicorn.css');
+		assert.equal(file.revHashMethod, 'md5');
 		cb();
 	});
 
@@ -18,6 +19,55 @@ it('should rev files', function (cb) {
 		contents: new Buffer('')
 	}));
 });
+
+it('should sha1 rev files', function (cb) {
+	var stream = rev({hashMethod: 'sha1'});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-da39a3ee.css');
+		assert.equal(file.revOrigPath, 'unicorn.css');
+		assert.equal(file.revHashMethod, 'sha1');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css',
+		contents: new Buffer('')
+	}));
+});
+
+it('should sha256 rev files', function (cb) {
+	var stream = rev({hashMethod: 'sha256'});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-e3b0c442.css');
+		assert.equal(file.revOrigPath, 'unicorn.css');
+		assert.equal(file.revHashMethod, 'sha256');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css',
+		contents: new Buffer('')
+	}));
+});
+
+it('should sha512 rev files', function (cb) {
+	var stream = rev({hashMethod: 'sha512'});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-cf83e135.css');
+		assert.equal(file.revOrigPath, 'unicorn.css');
+		assert.equal(file.revHashMethod, 'sha512');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css',
+		contents: new Buffer('')
+	}));
+});
+
 
 it('should build a rev manifest file', function (cb) {
 	var stream = rev.manifest();
@@ -140,6 +190,7 @@ it('should store the hashes for later', function (cb) {
 		assert.equal(file.path, 'unicorn-d41d8cd9.css');
 		assert.equal(file.revOrigPath, 'unicorn.css');
 		assert.equal(file.revHash, 'd41d8cd9');
+		assert.equal(file.revHashMethod, 'md5');
 		cb();
 	});
 


### PR DESCRIPTION
Hash method must be one of the items listed in crypto.getHashes().
e.g. md5, sha1, sha256, sha512.

Doesn't change the default hash method - md5.
The hash method of each rev'd file is stored at ``file.revHashMethod``.