### PR TITLE
Detect ENOENT by code instead of errno

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function getManifestFile(opts, cb) {
 	file.read(opts.path, opts, function (err, manifest) {
 		if (err) {
 			// not found
-			if (err.errno === 34) {
+			if (err.code === 'ENOENT') {
 				cb(null, new gutil.File(opts));
 			} else {
 				cb(err);


### PR DESCRIPTION
I believe the errno value has changed between Node.js versions (specifically,
it was not `34` in v0.11.14). Changed this to detect on the error code instead
of the errno, since the actual error is the same across Node versions.

This was causing the following error in Node v0.11.14:
```
events.js:85                                                                  
      throw er; // Unhandled 'error' event                                    
            ^                                                                 
Error: ENOENT, stat '/code/my-project/build/assets/manifest.json'
    at Error (native)                                                         
```

With this change, the test suite now passes in 0.10.35 and 0.11.14.