### PR TITLE
Added two options to rev(): 'hasher' and 'transformer'.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,25 @@ gulp.task('default', function () {
 
 ## API
 
-### rev()
+### rev([options])
+
+#### options
+
+##### hasher
+
+Type: `function(file)`
+Default: `rev.md5Hasher`
+
+Override the default file name hasher with a function that returns a hash. 
+
+##### transformer
+
+Type: `function(file, hash)`
+Default: `rev.defaultTransformer`
+
+Override the default file name transformer with a function that returns the transformed file name.
+
+`rev.fullextTransformer` is also available if you want your names to be `unicorn-hash.min.css` instead of `unicorn.min-hash.css`.
 
 ### rev.manifest([path], [options])
 

--- a/test.js
+++ b/test.js
@@ -232,3 +232,39 @@ it('should be okay when the optional sourcemap.file is not defined', function (c
 		contents: new Buffer(JSON.stringify({}))
 	}));
 });
+
+it('should allow custom hashers to be used', function (cb) {
+	var stream = rev({
+		hasher: function (file) {
+			return 'testhash';
+		}
+	});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-testhash.css');
+		assert.equal(file.revOrigPath, 'unicorn.css');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css',
+		contents: new Buffer('')
+	}));
+});
+
+it('should allow custom transformers to be used', function (cb) {
+	var stream = rev({
+		transformer: rev.fullextTransformer
+	});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-d41d8cd9.min.css');
+		assert.equal(file.revOrigPath, 'unicorn.min.css');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.min.css',
+		contents: new Buffer('')
+	}));
+});


### PR DESCRIPTION
(and also updated test.js and readme.md accordingly.)

These two options allow users to provide their own hashing functions and also their own filename transformer.

I did this because my files were getting named like "file.min-d53as53.css" and I wanted "file-d53as53.min.css". Maybe there was another way of doing this, but I felt like coding so I did. (Custom hasher is just an extra.)

Please note that while the tests pass, I am sure there will be problems with sourcemaps. Since I don't use external sourcemaps at the moment, I didn't have a proper environment to test sourcemap related part(s).

```javascript
if (pathMap[reverseFilename]) {
	// save the old path for later
	file.revOrigPath = file.path;
	file.revOrigBase = file.base;

	var hash = pathMap[reverseFilename];
	var origPath = path.join(path.dirname(file.path), path.basename(file.path, '.map'));
	var ext = path.extname(origPath);
	var filename = path.basename(origPath, ext) + '-' + hash + ext + '.map';
	file.path = path.join(path.dirname(origPath), filename);
} else {
	transformFilename(file, opts.transformer, opts.hasher);
}
```

If someone can take care of this name transformation which is done out of `transformFilename()`, it should work fine.
