### PR TITLE
Add hashLength and salt options to rev()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,12 @@ var through = require('through2');
 var objectAssign = require('object-assign');
 var file = require('vinyl-file');
 
-function md5(str) {
-	return crypto.createHash('md5').update(str).digest('hex');
+function md5(str, salt) {
+	var hash = crypto.createHash('md5').update(str);
+        if (salt) {
+                hash.update(salt, 'utf8');
+        }
+        return hash.digest('hex');
 }
 
 function relPath(base, filePath) {
@@ -41,20 +45,25 @@ function getManifestFile(opts, cb) {
 	});
 }
 
-function transformFilename(file) {
+function transformFilename(file, opts) {
 	// save the old path for later
 	file.revOrigPath = file.path;
 	file.revOrigBase = file.base;
 
-	var hash = file.revHash = md5(file.contents).slice(0, 8);
+	var hash = file.revHash = md5(file.contents, opts.salt).slice(0, opts.hashLength);
 	var ext = path.extname(file.path);
 	var filename = path.basename(file.path, ext) + '-' + hash + ext;
 	file.path = path.join(path.dirname(file.path), filename);
 }
 
-var plugin = function () {
+var plugin = function (opts) {
 	var sourcemaps = [];
-	var pathMap = {};
+        var pathMap = {};
+
+        opts = objectAssign({
+                salt: null,
+                hashLength: 8
+	}, opts);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -75,7 +84,7 @@ var plugin = function () {
 		}
 
 		var oldPath = file.path;
-		transformFilename(file);
+		transformFilename(file, opts);
 		pathMap[oldPath] = file.revHash;
 		cb(null, file);
 
@@ -103,7 +112,7 @@ var plugin = function () {
 				var filename = path.basename(origPath, ext) + '-' + hash + ext + '.map';
 				file.path = path.join(path.dirname(origPath), filename);
 			} else {
-				transformFilename(file);
+				transformFilename(file, opts);
 			}
 
 			this.push(file);

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,23 @@ gulp.task('default', function () {
 
 ## API
 
-### rev()
+### rev([options])
+
+#### options
+
+##### hashLength
+
+Type: `number`  
+Default: `8`
+
+The length of the hash appended to each filename.
+
+##### salt
+
+Type: `string`  
+Default: null
+
+Optional salt to apply to the hash of every file. Useful if you want to invalidate the cache by changing the cachebusting hash for every file without actually changing their contents.
 
 ### rev.manifest([path], [options])
 


### PR DESCRIPTION
Both are optional.

`hashLength` allows you to modify the length of the hash (defaults to 8, which is the current hard-coded value).

`salt` is an optional string that is applied to every file when generating a hash, in addition to the file contents. This will result in a different md5 hash being created. It is useful if you want to invalidate the current cache of files by changing the cachebusting hashes, without actually changing the contents of the files. You could also use a different salt per deployment for example if the files needed to exist side-by-side.