### PR TITLE
Remove redundant base path in manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,11 +127,11 @@ plugin.manifest = function (pth, opts) {
 
 		firstFileBase = firstFileBase || file.base;
 
-		var revisionedFile = relPath(firstFileBase, file.path),
-			originalFile = path.join(
-				path.dirname(revisionedFile),
-				path.basename(file.revOrigPath)
-			);
+		var revisionedFile = relPath(firstFileBase, file.path);
+		var originalFile = path.join(
+			path.dirname(revisionedFile),
+			path.basename(file.revOrigPath)
+		);
 
 		manifest[originalFile] = revisionedFile;
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ plugin.manifest = function (pth, opts) {
 		merge: false
 	}, opts, pth);
 
-	var firstFile = null;
+	var firstFileBase = null;
 	var manifest  = {};
 
 	return through.obj(function (file, enc, cb) {
@@ -125,8 +125,15 @@ plugin.manifest = function (pth, opts) {
 			return;
 		}
 
-		firstFile = firstFile || file;
-		manifest[relPath(firstFile.revOrigBase, file.revOrigPath)] = relPath(firstFile.base, file.path);
+		firstFileBase = firstFileBase || file.base;
+
+		var revisionedFile = relPath(firstFileBase, file.path),
+			originalFile = path.join(
+				path.dirname(revisionedFile),
+				path.basename(file.revOrigPath)
+			);
+
+		manifest[originalFile] = revisionedFile;
 
 		cb();
 	}, function (cb) {

--- a/test.js
+++ b/test.js
@@ -154,6 +154,48 @@ it('should respect directories', function (cb) {
 	stream.end();
 });
 
+it('should respect files coming from directories with different bases', function (cb) {
+	var stream = rev.manifest();
+
+	stream.on('data', function (newFile) {
+		var MANIFEST = {};
+		MANIFEST[path.join('foo', 'scriptfoo.js')] = path.join('foo', 'scriptfoo-d41d8cd98f.js');
+		MANIFEST[path.join('bar', 'scriptbar.js')] = path.join('bar', 'scriptbar-d41d8cd98f.js');
+
+		assert.equal(newFile.relative, 'rev-manifest.json');
+		assert.deepEqual(JSON.parse(newFile.contents.toString()), MANIFEST);
+		cb();
+	});
+
+	var file1 = new gutil.File({
+		cwd: __dirname,
+		base: path.join(__dirname, 'output'),
+		path: path.join(__dirname, 'output', 'foo', 'scriptfoo-d41d8cd98f.js'),
+		contents: new Buffer('')
+	});
+
+	file1.revOrigBase = path.join(__dirname, 'vendor1');
+	file1.revOrigPath = path.join(__dirname, 'vendor1', 'foo', 'scriptfoo.js');
+	file1.origName = 'scriptfoo.js';
+	file1.revName = 'scriptfoo-d41d8cd98f.js';
+
+	var file2 = new gutil.File({
+		cwd: __dirname,
+		base: path.join(__dirname, 'output'),
+		path: path.join(__dirname, 'output', 'bar', 'scriptbar-d41d8cd98f.js'),
+		contents: new Buffer('')
+	});
+
+	file2.revOrigBase = path.join(__dirname, 'vendor2');
+	file2.revOrigPath = path.join(__dirname, 'vendor2', 'bar', 'scriptbar.js');
+	file2.origName = 'scriptfoo.js';
+	file2.revName = 'scriptfoo-d41d8cd98f.js';
+
+	stream.write(file1);
+	stream.write(file2);
+	stream.end();
+});
+
 it('should store the hashes for later', function (cb) {
 	var stream = rev();
 


### PR DESCRIPTION
Let's say that `gulp.src()` was invoked like this:

    gulp.src([
        'app/assets/js/**/*.js', // first source dir
        'app/assets/vendor/**/*.js' // second source dir
    ])

In this case, `firstFile` would be equal to a first encountered file, and it would be a file from first directory. That would cause `relPath()` to return absolute path to a resource for each file that comes from a
second or any other subsequent directory.

As a result, manifest json would look like:

    {
        // comes from the first source dir
        'app.js': 'app-01020304.js',
        'test.js': 'test-01020304.js',
    
        // comes from second source dir
        '/home/foo/dev/app/assets/vendor/moxie.js': 'moxie-01020304.js',
        '/home/foo/dev/app/assets/vendor/bar/quux.js': 'bar/quux-01020304.js'
    }

This patch changes that behavior. Instead of relying on first encountered file's base path for all remaining files, manifest key is determined by combining original file name, and a relative path name used to save revved file into a directory given to `gulp.dest()`.