### PR TITLE
Sort rev manifest keys.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var objectAssign = require('object-assign');
 var file = require('vinyl-file');
 var revHash = require('rev-hash');
 var revPath = require('rev-path');
+var sortKeys = require('sort-keys');
 
 function relPath(base, filePath) {
 	if (filePath.indexOf(base) !== 0) {
@@ -155,7 +156,7 @@ plugin.manifest = function (pth, opts) {
 				manifest = objectAssign(oldManifest, manifest);
 			}
 
-			manifestFile.contents = new Buffer(JSON.stringify(manifest, null, '  '));
+			manifestFile.contents = new Buffer(JSON.stringify(sortKeys(manifest), null, '  '));
 			this.push(manifestFile);
 			cb();
 		}.bind(this));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "object-assign": "^2.0.0",
     "rev-hash": "^1.0.0",
     "rev-path": "^1.0.0",
+    "sort-keys": "^1.0.0",
     "through2": "^0.6.1",
     "vinyl-file": "^1.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -112,6 +112,39 @@ it('should not append to an existing rev manifest by default', function (cb) {
 
 });
 
+it('should sort the rev manifest keys', function (cb) {
+	var stream = rev.manifest({
+		path: 'test.manifest-fixture.json',
+		merge: true
+	});
+
+	stream.on('data', function (newFile) {
+		assert.deepEqual(
+			Object.keys(JSON.parse(newFile.contents.toString())),
+			['app.js', 'pony.css', 'unicorn.css']
+		);
+		cb();
+	});
+
+	var file = new gutil.File({
+		path: 'unicorn-d41d8cd98f.css',
+		contents: new Buffer('')
+	});
+
+	file.revOrigPath = 'unicorn.css';
+
+	var fileTwo = new gutil.File({
+		path: 'pony-d41d8cd98f.css',
+		contents: new Buffer('')
+	});
+
+	fileTwo.revOrigPath = 'pony.css';
+
+	stream.write(file);
+	stream.write(fileTwo);
+	stream.end();
+});
+
 it('should respect directories', function (cb) {
 	var stream = rev.manifest();
 


### PR DESCRIPTION
This makes manifest order deterministic, makes merges sane, and minimizes diffs.

Closes #112