### PR TITLE
Added force option to plugin.manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,13 +112,24 @@ plugin.manifest = function (pth, opts) {
 
 	opts = objectAssign({
 		path: 'rev-manifest.json',
-		merge: false
+		merge: false,
+		force: false
+
 	}, opts, pth);
 
 	var firstFileBase = null;
 	var manifest = {};
 
 	return through.obj(function (file, enc, cb) {
+
+		// writes the manifest file in force mode
+		if (opts.force && file.path && !file.revOrigPath) {
+			firstFileBase = firstFileBase || file.base;
+			manifest[relPath(firstFileBase, file.path)] = relPath(firstFileBase, file.path);	
+			cb();
+			return;
+		}
+
 		// ignore all non-rev'd files
 		if (!file.path || !file.revOrigPath) {
 			cb();

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ Merge existing manifest file.
 Type: `boolean`
 Default: `false`
 
-Write to manifest, even whit non-rev occurrences.
+Write to manifest, even with non-rev occurrences.
 
 ### Original path
 

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,12 @@ Default: `false`
 
 Merge existing manifest file.
 
+##### force
+
+Type: `boolean`
+Default: `false`
+
+Write to manifest, even whit non-rev occurrences.
 
 ### Original path
 


### PR DESCRIPTION
The force option enables writing to rev-manifest even when non-rev occurrences of files.

This is useful for me for example, because my app constantly reads the rev-manifest. And the gulp-rev is only enabled when the env `--production` is set, so by this way I'm able to continue my development with or without the `--production` set.