### PR TITLE
transformFilename treats the extension as being after the first dot

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,12 @@ function transformFilename(file) {
 	file.revOrigPath = file.path;
 	file.revOrigBase = file.base;
 	file.revHash = revHash(file.contents);
-	file.path = revPath(file.path, file.revHash);
+	var extIndex = file.path.indexOf('.');
+	if (extIndex >= 0) {
+	  file.path = revPath(file.path.slice(0, extIndex), file.revHash) + file.path.slice(extIndex);
+	} else {
+	  file.path = revPath(file.path, file.revHash);
+	}
 }
 
 var plugin = function () {

--- a/test.js
+++ b/test.js
@@ -19,6 +19,22 @@ it('should rev files', function (cb) {
 	}));
 });
 
+it('should add the revision hash before the first `.` in the filename', function (cb) {
+	var stream = rev();
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-d41d8cd98f.css.map');
+		assert.equal(file.revOrigPath, 'unicorn.css.map');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css.map',
+		contents: new Buffer('')
+	}));
+	stream.end();
+});
+
 it('should build a rev manifest file', function (cb) {
 	var stream = rev.manifest();
 


### PR DESCRIPTION
Fixes #88 by implementing the decision at https://github.com/sindresorhus/gulp-rev/issues/88#issuecomment-73474498