### PR TITLE
Correctly handle a dot in the path

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function transformFilename(file) {
 	file.revOrigBase = file.base;
 	file.revHash = revHash(file.contents);
 
-	var extIndex = file.path.indexOf('.');
+	var extIndex = file.path.indexOf('.', file.path.lastIndexOf('/'));
 
 	file.path = extIndex === -1 ?
 		revPath(file.path, file.revHash) :

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var file = require('vinyl-file');
 var revHash = require('rev-hash');
 var revPath = require('rev-path');
 var sortKeys = require('sort-keys');
+var modifyFilename = require('modify-filename');
 
 function relPath(base, filePath) {
 	if (filePath.indexOf(base) !== 0) {
@@ -45,11 +46,15 @@ function transformFilename(file) {
 	file.revOrigBase = file.base;
 	file.revHash = revHash(file.contents);
 
-	var extIndex = file.path.indexOf('.', file.path.lastIndexOf('/'));
+	file.path = modifyFilename(file.path, function (filename, extension) {
+		var extIndex = filename.indexOf('.');
 
-	file.path = extIndex === -1 ?
-		revPath(file.path, file.revHash) :
-		revPath(file.path.slice(0, extIndex), file.revHash) + file.path.slice(extIndex);
+		filename = extIndex === -1 ?
+			revPath(filename, file.revHash) :
+			revPath(filename.slice(0, extIndex), file.revHash) + filename.slice(extIndex);
+
+		return filename + extension;
+	});
 }
 
 var plugin = function () {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
+    "modify-filename": "^1.1.0",
     "object-assign": "^4.0.1",
     "rev-hash": "^1.0.0",
     "rev-path": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -323,3 +323,18 @@ it('should be okay when the optional sourcemap.file is not defined', function (c
 		contents: new Buffer(JSON.stringify({}))
 	}));
 });
+
+it('should handle a . in the folder name', function (cb) {
+	var stream = rev();
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'mysite.io/unicorn-d41d8cd98f.css');
+		assert.equal(file.revOrigPath, 'mysite.io/unicorn.css');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'mysite.io/unicorn.css',
+		contents: new Buffer('')
+	}));
+});


### PR DESCRIPTION
Off the back of #88 instead of just using the first `.` in the filename, now using the first `.` after the last `/` (or just the first `.` if no `/` is present). This accounts for folders in the path containing a `.` - at present something like `mysite.com/app/main.css` is revved to `mysite-ed79357abc.com/app/main.css`.