### PR TITLE
Better handling of filenames with > 1 periods

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function transformFilename(file) {
 	file.revHash = revHash(file.contents);
 
 	file.path = modifyFilename(file.path, function (filename, extension) {
-		var extIndex = filename.indexOf('.');
+		var extIndex = filename.lastIndexOf('.');
 
 		filename = extIndex === -1 ?
 			revPath(filename, file.revHash) :


### PR DESCRIPTION
e.g. Aaa.Bbb.Ccc.ext => Aaa.Bbb.Ccc-XXX.ext rather than Aaa-XXX.Bbb.Ccc.ext