### PR TITLE
manifest flatten option added

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,8 @@ plugin.manifest = function (pth, opts) {
 		var originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
 
 		if (opts.flatten) {
-			revisionedFile = relPath(file.revOrigBase, file.path);
+			originalFile = relPath(firstFileBase, file.revOrigPath);
+			revisionedFile = relPath(firstFileBase, file.path);
 		}
 
 		manifest[originalFile] = revisionedFile;

--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ plugin.manifest = function (pth, opts) {
 
 	opts = objectAssign({
 		path: 'rev-manifest.json',
-		merge: false
+		merge: false,
+		flatten: false
 	}, opts, pth);
 
 	var firstFileBase = null;
@@ -139,6 +140,10 @@ plugin.manifest = function (pth, opts) {
 
 		var revisionedFile = relPath(firstFileBase, file.path);
 		var originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
+
+		if (opts.flatten) {
+			revisionedFile = relPath(file.revOrigBase, file.path);
+		}
 
 		manifest[originalFile] = revisionedFile;
 

--- a/test.js
+++ b/test.js
@@ -59,6 +59,53 @@ it('should build a rev manifest file', function (cb) {
 	stream.end();
 });
 
+it('should build a flatten rev manifest file', function (cb) {
+	var stream = rev.manifest({flatten: true});
+
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.relative, 'rev-manifest.json');
+		assert.deepEqual(
+			JSON.parse(newFile.contents.toString()),
+			{'foo/bar/unicorn.css': 'unicorn-d41d8cd98f.css'}
+		);
+		cb();
+	});
+
+	var file = new gutil.File({
+		path: 'foo/bar/unicorn-d41d8cd98f.css',
+		contents: new Buffer('')
+	});
+
+	file.revOrigPath = 'foo/bar/unicorn.css';
+	file.revOrigBase = 'foo/bar/';
+
+	stream.write(file);
+	stream.end();
+});
+
+it('should build a not flatten rev manifest file', function (cb) {
+	var stream = rev.manifest({flatten: true});
+
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.relative, 'rev-manifest.json');
+		assert.deepEqual(
+			JSON.parse(newFile.contents.toString()),
+			{'foo/bar/unicorn.css': 'foo/bar/unicorn-d41d8cd98f.css'}
+		);
+		cb();
+	});
+
+	var file = new gutil.File({
+		path: 'foo/bar/unicorn-d41d8cd98f.css',
+		contents: new Buffer('')
+	});
+
+	file.revOrigPath = 'foo/bar/unicorn.css';
+
+	stream.write(file);
+	stream.end();
+});
+
 it('should allow naming the manifest file', function (cb) {
 	var path = 'manifest.json';
 	var stream = rev.manifest({path: path});
@@ -321,20 +368,5 @@ it('should be okay when the optional sourcemap.file is not defined', function (c
 	stream.end(new gutil.File({
 		path: 'pastissada.css.map',
 		contents: new Buffer(JSON.stringify({}))
-	}));
-});
-
-it('should handle a . in the folder name', function (cb) {
-	var stream = rev();
-
-	stream.on('data', function (file) {
-		assert.equal(file.path, 'mysite.io/unicorn-d41d8cd98f.css');
-		assert.equal(file.revOrigPath, 'mysite.io/unicorn.css');
-		cb();
-	});
-
-	stream.write(new gutil.File({
-		path: 'mysite.io/unicorn.css',
-		contents: new Buffer('')
 	}));
 });

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ it('should build a flatten rev manifest file', function (cb) {
 });
 
 it('should build a not flatten rev manifest file', function (cb) {
-	var stream = rev.manifest({flatten: true});
+	var stream = rev.manifest({flatten: false});
 
 	stream.on('data', function (newFile) {
 		assert.equal(newFile.relative, 'rev-manifest.json');
@@ -101,6 +101,7 @@ it('should build a not flatten rev manifest file', function (cb) {
 	});
 
 	file.revOrigPath = 'foo/bar/unicorn.css';
+	file.revOrigBase = 'foo/bar/';
 
 	stream.write(file);
 	stream.end();

--- a/test.js
+++ b/test.js
@@ -72,12 +72,12 @@ it('should build a flatten rev manifest file', function (cb) {
 	});
 
 	var file = new gutil.File({
-		path: 'foo/bar/unicorn-d41d8cd98f.css',
+		path: path.join(__dirname, 'unicorn-d41d8cd98f.css'),
 		contents: new Buffer('')
 	});
 
-	file.revOrigPath = 'foo/bar/unicorn.css';
-	file.revOrigBase = 'foo/bar/';
+	file.revOrigPath = path.join(__dirname, 'foo/bar/unicorn.css');
+	file.revOrigBase = path.join(__dirname);
 
 	stream.write(file);
 	stream.end();


### PR DESCRIPTION
this allows to flatten files with gulp-flatten and still have a valid manifest file. could fix https://github.com/sindresorhus/gulp-rev/issues/118

``````
js
var gulp = require('gulp');
var flatten = require('gulp-flatten')
var rev = require('gulp-rev');
//var imagemin   = require('gulp-imagemin');

gulp.task('images', function() {
  return gulp.src('./fixture/assets/images/**/*.+(jpg|jpeg|ico|png|gif|svg)')
    //.pipe(imagemin()) // Optimize
    .pipe(rev())
    .pipe(flatten())
    .pipe(gulp.dest('./fixture/build/images'))
    .pipe(rev.manifest({flatten: true}))
    .pipe(gulp.dest('./fixture/build'));
});
``````
