### PR TITLE
Add gulp-rev-delete-original to Documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ For more info on how to integrate **gulp-rev** into your app, have a look at the
 - [gulp-rev-outdated](https://github.com/shonny-ua/gulp-rev-outdated) - Old static asset revision files filter
 - [gulp-rev-collector](https://github.com/shonny-ua/gulp-rev-collector) - Static asset revision data collector
 - [rev-del](https://github.com/callumacrae/rev-del) - Delete old unused assets
+- [gulp-rev-delete-original](https://github.com/nib-health-funds/gulp-rev-delete-original) - Delete original files after rev
 - [gulp-rev-loader](https://github.com/adjavaherian/gulp-rev-loader) - Use rev-manifest with webpack
 
 ## License


### PR DESCRIPTION
I took a while to find out how to delete the original files and I found [here](https://github.com/sindresorhus/gulp-rev/pull/144#issuecomment-172327471) only. I believe if it's on the Readme file will be easy for others.