### PR TITLE
Added support for custom hashes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,11 +40,11 @@ function getManifestFile(opts, cb) {
 	});
 }
 
-function transformFilename(file) {
+function transformFilename(file, customHash) {
 	// save the old path for later
 	file.revOrigPath = file.path;
 	file.revOrigBase = file.base;
-	file.revHash = revHash(file.contents);
+	file.revHash = customHash || revHash(file.contents);
 
 	file.path = modifyFilename(file.path, function (filename, extension) {
 		var extIndex = filename.indexOf('.');
@@ -57,9 +57,13 @@ function transformFilename(file) {
 	});
 }
 
-var plugin = function () {
+var plugin = function (opts) {
 	var sourcemaps = [];
 	var pathMap = {};
+
+	opts = objectAssign({
+		customHash: false
+	}, opts);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -80,7 +84,7 @@ var plugin = function () {
 		}
 
 		var oldPath = file.path;
-		transformFilename(file);
+		transformFilename(file, opts.customHash);
 		pathMap[oldPath] = file.revHash;
 
 		cb(null, file);

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,16 @@ gulp.task('default', function () {
 
 ## API
 
-### rev()
+### rev([options])
+
+#### options
+
+##### customHash
+
+Type: `string`  
+Default: false
+
+Use a custom hash as the file revision.
 
 ### rev.manifest([path], [options])
 

--- a/test.js
+++ b/test.js
@@ -19,6 +19,21 @@ it('should rev files', function (cb) {
 	}));
 });
 
+it('should rev files with a custom hash', function (cb) {
+	var stream = rev({customHash: 'test'});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn-test.css');
+		assert.equal(file.revOrigPath, 'unicorn.css');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.css',
+		contents: new Buffer('')
+	}));
+});
+
 it('should add the revision hash before the first `.` in the filename', function (cb) {
 	var stream = rev();
 


### PR DESCRIPTION
Allow the use of a custom hash as the file revision:

`rev({customHash: 'this-is-custom'})`