### PR TITLE
Store the original paths in manifest.

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ plugin.manifest = function (pth, opts) {
 		}
 
 		var revisionedFile = relPath(file.base, file.path);
-		var originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
+		var originalFile = relPath(file.revOrigBase, file.revOrigPath);
 
 		manifest[originalFile] = revisionedFile;
 

--- a/test.js
+++ b/test.js
@@ -344,8 +344,8 @@ it('should use correct base path for each file', function (cb) {
 
 	stream.on('data', function (newFile) {
 		var MANIFEST = {};
-		MANIFEST[path.join('foo', 'scriptfoo.js')] = path.join('foo', 'scriptfoo-d41d8cd98f.js');
-		MANIFEST[path.join('bar', 'scriptbar.js')] = path.join('bar', 'scriptbar-d41d8cd98f.js');
+		MANIFEST['scriptfoo.js'] = path.join('foo', 'scriptfoo-d41d8cd98f.js');
+		MANIFEST['scriptbar.js'] = path.join('bar', 'scriptbar-d41d8cd98f.js');
 
 		assert.deepEqual(JSON.parse(newFile.contents.toString()), MANIFEST);
 		cb();


### PR DESCRIPTION
There is no common sense to store in manifest same paths which differs only with rev: `foo/bar.js: foo/bar.d41d8cd98f.js`. More useful to store the original file paths. `src/js/bar/bar.js: dist/js/bar.d41d8cd98f.js`
This also resolves #118.