### PR TITLE
Added option to specify custom transformer for the manifest file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,11 @@ plugin.manifest = function (pth, opts) {
 
 	opts = objectAssign({
 		path: 'rev-manifest.json',
-		merge: false
+		merge: false,
+		// Apply the default JSON transformer. 
+		// The user can pass in his on transformer if he wants. The only requirement is that it should
+		// support 'parse' and 'stringify' methods.
+		transformer: JSON
 	}, opts, pth);
 
 	var manifest = {};
@@ -157,13 +161,13 @@ plugin.manifest = function (pth, opts) {
 				var oldManifest = {};
 
 				try {
-					oldManifest = JSON.parse(manifestFile.contents.toString());
+					oldManifest = opts.transformer.parse(manifestFile.contents.toString());
 				} catch (err) {}
 
 				manifest = objectAssign(oldManifest, manifest);
 			}
 
-			manifestFile.contents = new Buffer(JSON.stringify(sortKeys(manifest), null, '  '));
+			manifestFile.contents = new Buffer(opts.transformer.stringify(sortKeys(manifest), null, '  '));
 			this.push(manifestFile);
 			cb();
 		}.bind(this));

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ plugin.manifest = function (pth, opts) {
 	opts = objectAssign({
 		path: 'rev-manifest.json',
 		merge: false,
-		// Apply the default JSON transformer. 
+		// Apply the default JSON transformer.
 		// The user can pass in his on transformer if he wants. The only requirement is that it should
 		// support 'parse' and 'stringify' methods.
 		transformer: JSON

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # gulp-rev [![Build Status](https://travis-ci.org/sindresorhus/gulp-rev.svg?branch=master)](https://travis-ci.org/sindresorhus/gulp-rev)
 
-> Static asset revisioning by appending content hash to filenames  
+> Static asset revisioning by appending content hash to filenames
 > `unicorn.css` → `unicorn-d41d8cd98f.css`
 
 Make sure to set the files to [never expire](http://developer.yahoo.com/performance/rules.html#expires) for this to have an effect.
@@ -35,7 +35,7 @@ gulp.task('default', function () {
 
 #### path
 
-Type: `string`  
+Type: `string`
 Default: `"rev-manifest.json"`
 
 Manifest file path.
@@ -44,24 +44,32 @@ Manifest file path.
 
 ##### base
 
-Type: `string`  
+Type: `string`
 Default: `process.cwd()`
 
 Override the `base` of the manifest file.
 
 ##### cwd
 
-Type: `string`  
+Type: `string`
 Default: `process.cwd()`
 
 Override the `cwd` (current working directory) of the manifest file.
 
 ##### merge
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Merge existing manifest file.
+
+##### transformer
+
+Type: `object`
+Default: `JSON`
+
+An object with `parse` and `stringify` methods. This can be used to provide a
+custom transformer instead of the default `JSON` for the manifest file.
 
 
 ### Original path


### PR DESCRIPTION
I added an option to specify a custom transformer for the output rev file.
For example if the user wants the output in YAML format instead of the default JSON format, he can specify like this
`
.pipe(rev.manifest('assets-manifest.yaml', {merge:true, transformer : require('yamljs')}))`

The transformer can be any object which has a `parse` and `stringify` function. The `yamljs` library in the above example already has those 2 functions, so it can be used directly.
This way even if the user wants the manifest in some specific format like for example, PHP associative array, then he can write a transformer for that.