### PR TITLE
Enhancement #168 add option to prepend hash before last dot

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,16 @@ gulp.task('default', function () {
 
 ## API
 
-### rev()
+### rev([options])
+
+#### options
+
+##### lastDot
+
+Type: `boolean`
+Default: `false`
+
+Preprend the hash before the final dot in the file path instead of the first
 
 ### rev.manifest([path], [options])
 

--- a/test.js
+++ b/test.js
@@ -36,6 +36,23 @@ it('should add the revision hash before the first `.` in the filename', function
 	stream.end();
 });
 
+it('can add the revision hash before the last `.` in the filename', function (cb) {
+	var stream = rev({lastDot: true});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, 'unicorn.liger-d41d8cd98f.css');
+		assert.equal(file.revOrigPath, 'unicorn.liger.css');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'unicorn.liger.css',
+		contents: new Buffer('')
+	}));
+
+	stream.end();
+});
+
 it('should build a rev manifest file', function (cb) {
 	var stream = rev.manifest();
 


### PR DESCRIPTION
### Resolves #168 

### What's new?

New options hash with option `lastDot` that preprends hash before last dot.

Example:

```
rev({lastDot: true})

Filename: foo.bar.baz -> foo.bar.012345689.baz
```