### PR TITLE
More realistic example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ An asset manifest, mapping the original paths to the revisioned paths, will be w
 ```json
 {
 	"css/unicorn.css": "css/unicorn-d41d8cd98f.css",
-	"js/unicorn.js": "js/unicorn-273c2cin3f.js"
+	"js/unicorn.js": "js/unicorn-273c2c123f.js"
 }
 ```
 


### PR DESCRIPTION
Most hexadecimal encoded hashes don't contain "i" nor "n" due to them being outside the 0-9a-fA-F range.