### PR TITLE
options.base of manifest didn't work in fact

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,9 @@ plugin.manifest = (pth, opts) => {
 			cb();
 			return;
 		}
-
+		if(opts.base){
+			opts.path=path.resolve(opts.base,opts.path)
+		}
 		getManifestFile(opts).then(manifestFile => {
 			if (opts.merge && !manifestFile.isNull()) {
 				let oldManifest = {};


### PR DESCRIPTION
I found the old manifest method didn't handle the opts.base in fact.And this was  also resulting in the wrong path(not just wrong,even unhandlable) of the rev-manifest.json file when the opts.merge was set to be true.So,add these lines to support the opts.base.


