### PR TITLE
Make tests independent of platform specific path separator (#219)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,14 @@ const sortKeys = require('sort-keys');
 const modifyFilename = require('modify-filename');
 
 function relPath(base, filePath) {
+	filePath = filePath.replace(/\\/g, '/');
+	base = base.replace(/\\/g, '/');
+
 	if (filePath.indexOf(base) !== 0) {
-		return filePath.replace(/\\/g, '/');
+		return filePath;
 	}
 
-	const newPath = filePath.slice(base.length).replace(/\\/g, '/');
+	const newPath = filePath.slice(base.length);
 
 	if (newPath[0] === '/') {
 		return newPath.slice(1);

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -126,8 +126,8 @@ test('respects directories', async t => {
 	}));
 
 	const MANIFEST = {};
-	MANIFEST[path.join('foo', 'unicorn.css').replace(/\\/g, '/')] = path.join('foo', 'unicorn-d41d8cd98f.css').replace(/\\/g, '/');
-	MANIFEST[path.join('bar', 'pony.css').replace(/\\/g, '/')] = path.join('bar', 'pony-d41d8cd98f.css').replace(/\\/g, '/');
+	MANIFEST['foo/unicorn.css'] = 'foo/unicorn-d41d8cd98f.css';
+	MANIFEST['bar/pony.css'] = 'bar/pony-d41d8cd98f.css';
 
 	const file = await data;
 	t.is(file.relative, 'rev-manifest.json');
@@ -159,8 +159,8 @@ test('respects files coming from directories with different bases', async t => {
 	}));
 
 	const MANIFEST = {};
-	MANIFEST[path.join('foo', 'scriptfoo.js').replace(/\\/g, '/')] = path.join('foo', 'scriptfoo-d41d8cd98f.js').replace(/\\/g, '/');
-	MANIFEST[path.join('bar', 'scriptbar.js').replace(/\\/g, '/')] = path.join('bar', 'scriptbar-d41d8cd98f.js').replace(/\\/g, '/');
+	MANIFEST['foo/scriptfoo.js'] = 'foo/scriptfoo-d41d8cd98f.js';
+	MANIFEST['bar/scriptbar.js'] = 'bar/scriptbar-d41d8cd98f.js';
 
 	const file = await data;
 	t.is(file.relative, 'rev-manifest.json');
@@ -185,8 +185,8 @@ test('uses correct base path for each file', async t => {
 	}));
 
 	const MANIFEST = {};
-	MANIFEST[path.join('foo', 'scriptfoo.js').replace(/\\/g, '/')] = path.join('foo', 'scriptfoo-d41d8cd98f.js').replace(/\\/g, '/');
-	MANIFEST[path.join('bar', 'scriptbar.js').replace(/\\/g, '/')] = path.join('bar', 'scriptbar-d41d8cd98f.js').replace(/\\/g, '/');
+	MANIFEST['foo/scriptfoo.js'] = 'foo/scriptfoo-d41d8cd98f.js';
+	MANIFEST['bar/scriptbar.js'] = 'bar/scriptbar-d41d8cd98f.js';
 
 	const file = await data;
 	t.deepEqual(JSON.parse(file.contents.toString()), MANIFEST);

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -126,8 +126,8 @@ test('respects directories', async t => {
 	}));
 
 	const MANIFEST = {};
-	MANIFEST[path.join('foo', 'unicorn.css')] = path.join('foo', 'unicorn-d41d8cd98f.css');
-	MANIFEST[path.join('bar', 'pony.css')] = path.join('bar', 'pony-d41d8cd98f.css');
+	MANIFEST[path.join('foo', 'unicorn.css').replace(/\\/g, '/')] = path.join('foo', 'unicorn-d41d8cd98f.css').replace(/\\/g, '/');
+	MANIFEST[path.join('bar', 'pony.css').replace(/\\/g, '/')] = path.join('bar', 'pony-d41d8cd98f.css').replace(/\\/g, '/');
 
 	const file = await data;
 	t.is(file.relative, 'rev-manifest.json');
@@ -159,8 +159,8 @@ test('respects files coming from directories with different bases', async t => {
 	}));
 
 	const MANIFEST = {};
-	MANIFEST[path.join('foo', 'scriptfoo.js')] = path.join('foo', 'scriptfoo-d41d8cd98f.js');
-	MANIFEST[path.join('bar', 'scriptbar.js')] = path.join('bar', 'scriptbar-d41d8cd98f.js');
+	MANIFEST[path.join('foo', 'scriptfoo.js').replace(/\\/g, '/')] = path.join('foo', 'scriptfoo-d41d8cd98f.js').replace(/\\/g, '/');
+	MANIFEST[path.join('bar', 'scriptbar.js').replace(/\\/g, '/')] = path.join('bar', 'scriptbar-d41d8cd98f.js').replace(/\\/g, '/');
 
 	const file = await data;
 	t.is(file.relative, 'rev-manifest.json');
@@ -174,19 +174,19 @@ test('uses correct base path for each file', async t => {
 	stream.write(createFile({
 		cwd: 'app/',
 		base: 'app/',
-		path: path.join('app', 'foo', 'scriptfoo-d41d8cd98f.js'),
+		path: path.join('app', 'foo', 'scriptfoo-d41d8cd98f.js').replace(/\\/g, '/'),
 		revOrigPath: 'scriptfoo.js'
 	}));
 	stream.end(createFile({
 		cwd: 'assets/',
 		base: 'assets/',
-		path: path.join('assets', 'bar', 'scriptbar-d41d8cd98f.js'),
+		path: path.join('assets', 'bar', 'scriptbar-d41d8cd98f.js').replace(/\\/g, '/'),
 		revOrigPath: 'scriptbar.js'
 	}));
 
 	const MANIFEST = {};
-	MANIFEST[path.join('foo', 'scriptfoo.js')] = path.join('foo', 'scriptfoo-d41d8cd98f.js');
-	MANIFEST[path.join('bar', 'scriptbar.js')] = path.join('bar', 'scriptbar-d41d8cd98f.js');
+	MANIFEST[path.join('foo', 'scriptfoo.js').replace(/\\/g, '/')] = path.join('foo', 'scriptfoo-d41d8cd98f.js').replace(/\\/g, '/');
+	MANIFEST[path.join('bar', 'scriptbar.js').replace(/\\/g, '/')] = path.join('bar', 'scriptbar-d41d8cd98f.js').replace(/\\/g, '/');
 
 	const file = await data;
 	t.deepEqual(JSON.parse(file.contents.toString()), MANIFEST);

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -174,13 +174,13 @@ test('uses correct base path for each file', async t => {
 	stream.write(createFile({
 		cwd: 'app/',
 		base: 'app/',
-		path: path.join('app', 'foo', 'scriptfoo-d41d8cd98f.js').replace(/\\/g, '/'),
+		path: path.join('app', 'foo', 'scriptfoo-d41d8cd98f.js'),
 		revOrigPath: 'scriptfoo.js'
 	}));
 	stream.end(createFile({
 		cwd: 'assets/',
 		base: 'assets/',
-		path: path.join('assets', 'bar', 'scriptbar-d41d8cd98f.js').replace(/\\/g, '/'),
+		path: path.join('assets', 'bar', 'scriptbar-d41d8cd98f.js'),
 		revOrigPath: 'scriptbar.js'
 	}));
 

--- a/test/rev.js
+++ b/test/rev.js
@@ -49,7 +49,7 @@ test.cb('handles sourcemaps transparently', t => {
 
 	stream.on('data', file => {
 		if (path.extname(file.path) === '.map') {
-			t.is(file.path, 'maps/pastissada-d41d8cd98f.css.map');
+			t.is(file.path, path.normalize('maps/pastissada-d41d8cd98f.css.map'));
 			t.end();
 		}
 	});
@@ -113,6 +113,6 @@ test('handles a `.` in the folder name', async t => {
 	}));
 
 	const file = await data;
-	t.is(file.path, 'mysite.io/unicorn-d41d8cd98f.css');
+	t.is(file.path, path.normalize('mysite.io/unicorn-d41d8cd98f.css'));
 	t.is(file.revOrigPath, 'mysite.io/unicorn.css');
 });


### PR DESCRIPTION
Resolves #219

Most of the path module's method will replace forward and backward
slashes with the platform specific path separator. And gulp-rev enforces
the use of forward slashes for the manifest. The tests didn't take these
two behaviors into account, which resulted in mismatches for some test
on platforms that use backward slashes as the path separator (i.e. the
Windows platform).

These mismatches are resolved by this patch by using `path.normalize()`
and `.replace(/\\/g, '/')` at the proper places in the tests.
