### PR TITLE
Pass resolved, absolute paths to relPath() (#220)

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ plugin.manifest = (pth, opts) => {
 			return;
 		}
 
-		const revisionedFile = relPath(file.base, file.path);
+		const revisionedFile = relPath(path.resolve(file.cwd, file.base), path.resolve(file.cwd, file.path));
 		const originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
 
 		manifest[originalFile] = revisionedFile;

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -178,9 +178,9 @@ test('uses correct base path for each file', async t => {
 		revOrigPath: 'scriptfoo.js'
 	}));
 	stream.end(createFile({
-		cwd: 'assets/',
+		cwd: '/',
 		base: 'assets/',
-		path: path.join('assets', 'bar', 'scriptbar-d41d8cd98f.js'),
+		path: path.join('/assets', 'bar', 'scriptbar-d41d8cd98f.js'),
 		revOrigPath: 'scriptbar.js'
 	}));
 


### PR DESCRIPTION
Resolves #220

The original code would fail to determine the correct relative path when
`file.base` is a relative path and `file.path` is absolute. We can fix
this by converting both paths to an absolute path (using `path.resolve()`
and `file.cwd`) before passing them to `relPath()`.

The *uses correct base path for each file* test in **manifest.js** was
also modified to take this relative-absolute case into consideration.

There is one ambiguous case where this might not work as expected. When both `file.cwd` and `file.base` are relative and the `cwd` is a parent of `base`, for example respectively **app/** and **app/sub/**. In that case the resulting resolve()-ed path would be **app/app/sub/** while the expected path might be **app/sub/** (although **app/app/sub/** might also be the correct path if you have a weird directory structure).
Nonetheless one could argue that the latter case is never going to present itself in normal code. Because, as far as my understanding of Vinyl objects goes, `cwd` is supposed to be an absolute path and if `base` isn't absolute, it will be relative to the absolute `cwd` path.