### PR TITLE
Add `force` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,16 @@ gulp.task('default', () =>
 
 ## API
 
-### rev()
+### rev([options])
+
+#### options
+
+##### forceRev
+
+Type: `string`<br>
+Default: `false`
+
+Override the `revHash` of the file. This can be used when you want the rev to run, but have predicitable results, and a manifest file.
 
 ### rev.manifest([path], [options])
 

--- a/test/rev.js
+++ b/test/rev.js
@@ -30,6 +30,19 @@ test('adds the revision hash before the first `.` in the filename', async t => {
 	t.is(file.revOrigPath, 'unicorn.css.map');
 });
 
+test('ability to override the `revHash` for debugging', async t => {
+	const stream = rev({forceRev: 'forcedRev'});
+	const data = pEvent(stream, 'data');
+
+	stream.end(createFile({
+		path: 'unicorn.css.map'
+	}));
+
+	const file = await data;
+	t.is(file.path, 'unicorn-forcedRev.css.map');
+	t.is(file.revOrigPath, 'unicorn.css.map');
+});
+
 test('stores the hashes for later', async t => {
 	const stream = rev();
 	const data = pEvent(stream, 'data');


### PR DESCRIPTION
### What's new?

#### forceRev option for rev()

The `forceRev` is useful when running in dev/debug mode. You might want to generate
the manifest file but you might not want to alter it if you are running
a watch on some files, as this would generate a new index.html file as
the paths are updated, this can make browsersync reload both the html
and the css, breaking the style reloading.

[This has also been implemented in an very old fork](https://www.npmjs.com/package/gulp-rev-forcerev).

This could apply to more situations where you want the manifest, but not
the hash part in certain situations. Like settings breakpoints in JavaScript.

- Added a test
- Added docs 


