### PR TITLE
Replace gulp-util with smaller modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 const path = require('path');
-const gutil = require('gulp-util');
 const through = require('through2');
 const vinylFile = require('vinyl-file');
 const revHash = require('rev-hash');
 const revPath = require('rev-path');
 const sortKeys = require('sort-keys');
 const modifyFilename = require('modify-filename');
+const Vinyl = require('vinyl');
+const PluginError = require('plugin-error');
 
 function relPath(base, filePath) {
 	filePath = filePath.replace(/\\/g, '/');
@@ -44,7 +45,7 @@ function transformFilename(file) {
 
 const getManifestFile = opts => vinylFile.read(opts.path, opts).catch(err => {
 	if (err.code === 'ENOENT') {
-		return new gutil.File(opts);
+		return new Vinyl(opts);
 	}
 
 	throw err;
@@ -61,7 +62,7 @@ const plugin = () => {
 		}
 
 		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-rev', 'Streaming not supported'));
+			cb(new PluginError('gulp-rev', 'Streaming not supported'));
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "assets"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.0",
     "modify-filename": "^1.1.0",
+    "plugin-error": "^0.1.2",
     "rev-hash": "^2.0.0",
     "rev-path": "^2.0.0",
     "sort-keys": "^2.0.0",
     "through2": "^2.0.0",
+    "vinyl": "^2.1.0",
     "vinyl-file": "^3.0.0"
   },
   "devDependencies": {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,7 +1,7 @@
-import gutil from 'gulp-util';
+import Vinyl from 'vinyl';
 
 function createFile({path, revOrigPath, revOrigBase, origName, revName, cwd, base, contents = ''}) {
-	const file = new gutil.File({
+	const file = new Vinyl({
 		path,
 		cwd,
 		base,


### PR DESCRIPTION
### Resolves #236

### What's new?
The `gulp-util` module is deprecated. `gutil.PluginError` is replaced by `plugin-error` and `gutil.File` is replaced by `vinyl`.