### PR TITLE
Fix a test failure on Windows

### DIFF
--- a/test/rev.js
+++ b/test/rev.js
@@ -114,5 +114,5 @@ test('handles a `.` in the folder name', async t => {
 
 	const file = await data;
 	t.is(file.path, path.normalize('mysite.io/unicorn-d41d8cd98f.css'));
-	t.is(file.revOrigPath, 'mysite.io/unicorn.css');
+	t.is(file.revOrigPath, path.normalize('mysite.io/unicorn.css'));
 });


### PR DESCRIPTION
Before:

```
C:\Users\xmr\Desktop\gulp-rev>npm t

> gulp-rev@9.0.0 test C:\Users\xmr\Desktop\gulp-rev
> xo && ava


  14 passed
  1 failed

  rev » handles a `.` in the folder name

  C:\Users\xmr\Desktop\gulp-rev\test\rev.js:117

   116:   t.is(file.path, path.normalize('mysite.io/unicorn-d41d8cd98f.css'));
   117:   t.is(file.revOrigPath, 'mysite.io/unicorn.css');
   118: });

  Difference:

  - 'mysite.io\\unicorn.css'
  + 'mysite.io/unicorn.css'
npm ERR! Test failed.  See above for more details.
```

After:

```
C:\Users\xmr\Desktop\gulp-rev>npm t

> gulp-rev@9.0.0 test C:\Users\xmr\Desktop\gulp-rev
> xo && ava


  15 passed
```

/CC @sindresorhus 
