### PR TITLE
Really put the hash before the extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,13 +33,10 @@ function transformFilename(file) {
 	file.revHash = revHash(file.contents);
 
 	file.path = modifyFilename(file.path, (filename, extension) => {
-		const extIndex = filename.lastIndexOf('.');
-
-		filename = extIndex === -1 ?
-			revPath(filename, file.revHash) :
-			revPath(filename.slice(0, extIndex), file.revHash) + filename.slice(extIndex);
-
-		return filename + extension;
+		if (path.extname(file.path) === '.map' || filename.endsWith('.min')) {
+			return revPath(filename, file.revHash) + extension;
+		}
+		return revPath(filename + extension, file.revHash);
 	});
 }
 


### PR DESCRIPTION
Second attempt, but we really need tests.

With master:

```json
{
  "dist/css/site.test.css": "dist/css/site-a55e80c2ce.test.css",
  "dist/css/site.test.min.css": "dist/css/site-a55e80c2ce.test.min.css",
  "dist/jquery.fancybox.min.css": "dist/jquery-1679dcd38f.fancybox.min.css",
  "dist/jquery.fancybox.min.js": "dist/jquery-b762d7a222.fancybox.min.js"
}
```

This branch:

```json
{
  "dist/css/site.test.css": "dist/css/site-a55e80c2ce.test.css",
  "dist/css/site.test.min.css": "dist/css/site.test-a55e80c2ce.min.css",
  "dist/jquery.fancybox.min.css": "dist/jquery.fancybox-1679dcd38f.min.css",
  "dist/jquery.fancybox.min.js": "dist/jquery.fancybox-b762d7a222.min.js",
}
```

As you can see the period issue isn't fixed in master either.
