### PR TITLE
Add gulp-rev-sri to docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,3 +206,4 @@ It may be useful - and necessary - to use `gulp-rev` with other packages to comp
 - [gulp-rev-delete-original](https://github.com/nib-health-funds/gulp-rev-delete-original) - Delete original files after rev
 - [gulp-rev-loader](https://github.com/adjavaherian/gulp-rev-loader) - Use rev-manifest with webpack
 - [gulp-rev-format](https://github.com/atamas101/gulp-rev-format) - Provide hash formatting options for static assets (prefix, suffix, last-extension)
+- [gulp-rev-sri](https://github.com/shaunwarman/gulp-rev-sri) - Add subresource integrity field to rev-manifest


### PR DESCRIPTION
Add [gulp-rev-sri](https://github.com/shaunwarman/gulp-rev-sri) to dev plugin section. This takes the files within the rev-manifest and creates a [subresource integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) field 