### PR TITLE
Add option to mutate the key created in manifest file

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,16 @@ plugin.manifest = (path_, options) => {
 		const revisionedFile = relativePath(path.resolve(file.cwd, file.base), path.resolve(file.cwd, file.path));
 		const originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
 
-		manifest[originalFile] = revisionedFile;
+		if (typeof opts.keyModifier === 'function') {
+			const originalFileModified = opts.keyModifier(originalFile);
+			if (typeof originalFileModified === 'string') {
+				manifest[originalFileModified] = revisionedFile;
+			} else {
+				manifest[originalFile] = revisionedFile;
+			}
+		} else {
+			manifest[originalFile] = revisionedFile;
+		}
 
 		callback();
 	}, function (callback) {

--- a/index.js
+++ b/index.js
@@ -165,20 +165,11 @@ plugin.manifest = (path_, options) => {
 
 		const revisionedFile = relativePath(path.resolve(file.cwd, file.base), path.resolve(file.cwd, file.path));
 		const originalFile = path.join(path.dirname(revisionedFile), path.basename(file.revOrigPath)).replace(/\\/g, '/');
+		const fileKey = getManifestKey(originalFile, opts);
 
-		if (typeof opts.keyModifier === 'function') {
-			const originalFileModified = opts.keyModifier(originalFile);
-			if (typeof originalFileModified === 'string') {
-				manifest[originalFileModified] = revisionedFile;
-			} else {
-				manifest[originalFile] = revisionedFile;
-			}
-		} else {
-			manifest[originalFile] = revisionedFile;
-		}
-
-		callback();
-	}, function (callback) {
+		manifest[fileKey] = getManifestValue(revisionedFile, opts);
+		cb();
+	}, function (cb) {
 		// No need to write a manifest file if there's nothing to manifest
 		if (Object.keys(manifest).length === 0) {
 			callback();

--- a/index.js
+++ b/index.js
@@ -68,6 +68,21 @@ function getManifestKey(key, opts) {
 
 	return keyResult;
 }
+
+function getManifestValue(value, opts) {
+	let valueResult = value;
+
+	if (typeof opts.valueModifier === 'function') {
+		valueResult = opts.valueModifier(value);
+		if (typeof valueResult !== 'string') {
+			throw new Error(`Non string result after valueModifier applied to ${value}`);
+		}
+	}
+
+	return valueResult;
+
+}
+
 const plugin = () => {
 	const sourcemaps = [];
 	const pathMap = {};

--- a/index.js
+++ b/index.js
@@ -55,6 +55,19 @@ const getManifestFile = async options => {
 	}
 };
 
+function getManifestKey(key, opts) {
+	let keyResult = key;
+
+	if (typeof opts.keyModifier === 'function') {
+		keyResult = opts.keyModifier(key);
+
+		if (typeof keyResult !== 'string') {
+			throw new Error(`Non string result after keyModifier applied to ${key}`);
+		}
+	}
+
+	return keyResult;
+}
 const plugin = () => {
 	const sourcemaps = [];
 	const pathMap = {};

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,11 @@ Default: `JSON`
 An object with `parse` and `stringify` methods. This can be used to provide a
 custom transformer instead of the default `JSON` for the manifest file.
 
+###### keyModifier
+Type: `Function`<br>
+Default: `null`
+
+Modify the generated `key` in the rev file.
 
 ### Original path
 


### PR DESCRIPTION
### Resolves {ISSUE_ID}

### What's new?
Options can now accept a `keyModifier` property which is a function that changes the key that is saved in the manifest file