### PR TITLE
Add link to gulp-rev-dist-clean in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,7 @@ It may be useful - and necessary - to use `gulp-rev` with other packages to comp
 - [gulp-rev-collector](https://github.com/shonny-ua/gulp-rev-collector) - Static asset revision data collector
 - [rev-del](https://github.com/callumacrae/rev-del) - Delete old unused assets
 - [gulp-rev-delete-original](https://github.com/nib-health-funds/gulp-rev-delete-original) - Delete original files after rev
+- [gulp-rev-dist-clean](https://github.com/alexandre-abrioux/gulp-rev-dist-clean) - Clean-up temporary and legacy files created by gulp-rev 
 - [gulp-rev-loader](https://github.com/adjavaherian/gulp-rev-loader) - Use rev-manifest with webpack
 - [gulp-rev-format](https://github.com/atamas101/gulp-rev-format) - Provide hash formatting options for static assets (prefix, suffix, last-extension)
 - [gulp-rev-sri](https://github.com/shaunwarman/gulp-rev-sri) - Add subresource integrity field to rev-manifest

--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ It may be useful - and necessary - to use `gulp-rev` with other packages to comp
 - [gulp-rev-collector](https://github.com/shonny-ua/gulp-rev-collector) - Static asset revision data collector
 - [rev-del](https://github.com/callumacrae/rev-del) - Delete old unused assets
 - [gulp-rev-delete-original](https://github.com/nib-health-funds/gulp-rev-delete-original) - Delete original files after rev
-- [gulp-rev-dist-clean](https://github.com/alexandre-abrioux/gulp-rev-dist-clean) - Clean-up temporary and legacy files created by gulp-rev 
+- [gulp-rev-dist-clean](https://github.com/alexandre-abrioux/gulp-rev-dist-clean) - Clean up temporary and legacy files created by gulp-rev 
 - [gulp-rev-loader](https://github.com/adjavaherian/gulp-rev-loader) - Use rev-manifest with webpack
 - [gulp-rev-format](https://github.com/atamas101/gulp-rev-format) - Provide hash formatting options for static assets (prefix, suffix, last-extension)
 - [gulp-rev-sri](https://github.com/shaunwarman/gulp-rev-sri) - Add subresource integrity field to rev-manifest


### PR DESCRIPTION
Hi! First of all thank you for maintaining this package! I used it quite a lot in the past and loved it :)

I created [gulp-rev-dist-clean](https://github.com/alexandre-abrioux/gulp-rev-dist-clean) back in 2017 out of a need I had to clean-up old files that had been removed from the `src` directory but that where still present in the `dist` directory even after running `gulp-rev`.

Usually you would completely empty the `dist` directory before running `gulp-rev`, so that everything in the `dist` directory would correspond to actual files in the `src` directory, but this could get heavy with huge builds in watch mode. To prevent re-building everything, especially images, each time a file changes, and to keep the `dist` directory "fresh", I needed a solution.

I tried other packages at that time, including `rev-del`, but it did not support this specific use-case, so I decided to develop my own.

Fast forward to today, I am still maintaining it and adding new features to it as it turns out it is also [used by others](https://github.com/alexandre-abrioux/gulp-rev-dist-clean/network/dependents). Therefore I wonder if we could add it to the list of "clean-up" tools offered by the community?

Thanks!