### PR TITLE
Update dependencies and move to ESM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 18
           - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
+          - 16
           - 14
-          - 12
-          - 10
-          - 8
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
-'use strict';
-const path = require('path');
-const through = require('through2');
-const vinylFile = require('vinyl-file');
-const revHash = require('rev-hash');
-const revPath = require('rev-path');
-const sortKeys = require('sort-keys');
-const modifyFilename = require('modify-filename');
-const Vinyl = require('vinyl');
-const PluginError = require('plugin-error');
+import {Buffer} from 'node:buffer';
+import path from 'node:path';
+import through from 'through2';
+import {vinylFile} from 'vinyl-file';
+import revHash from 'rev-hash';
+import {revPath} from 'rev-path';
+import sortKeys from 'sort-keys';
+import modifyFilename from 'modify-filename';
+import Vinyl from 'vinyl';
+import PluginError from 'plugin-error';
 
 function relativePath(base, filePath) {
 	filePath = filePath.replace(/\\/g, '/');
@@ -35,9 +35,9 @@ function transformFilename(file) {
 	file.path = modifyFilename(file.path, (filename, extension) => {
 		const extIndex = filename.lastIndexOf('.');
 
-		filename = extIndex === -1 ?
-			revPath(filename, file.revHash) :
-			revPath(filename.slice(0, extIndex), file.revHash) + filename.slice(extIndex);
+		filename = extIndex === -1
+			? revPath(filename, file.revHash)
+			: revPath(filename.slice(0, extIndex), file.revHash) + filename.slice(extIndex);
 
 		return filename + extension;
 	});
@@ -45,7 +45,7 @@ function transformFilename(file) {
 
 const getManifestFile = async options => {
 	try {
-		return await vinylFile.read(options.path, options);
+		return await vinylFile(options.path, options);
 	} catch (error) {
 		if (error.code === 'ENOENT') {
 			return new Vinyl(options);
@@ -89,7 +89,7 @@ const plugin = () => {
 			// Attempt to parse the sourcemap's JSON to get the reverse filename
 			try {
 				reverseFilename = JSON.parse(file.contents.toString()).file;
-			} catch (_) {}
+			} catch {}
 
 			if (!reverseFilename) {
 				reverseFilename = path.relative(path.dirname(file.path), path.basename(file.path, '.map'));
@@ -123,7 +123,7 @@ plugin.manifest = (path_, options) => {
 		merge: false,
 		transformer: JSON,
 		...options,
-		...path_
+		...path_,
 	};
 
 	let manifest = {};
@@ -157,7 +157,7 @@ plugin.manifest = (path_, options) => {
 
 					try {
 						oldManifest = options.transformer.parse(manifestFile.contents.toString());
-					} catch (_) {}
+					} catch {}
 
 					manifest = Object.assign(oldManifest, manifest);
 				}
@@ -172,4 +172,4 @@ plugin.manifest = (path_, options) => {
 	});
 };
 
-module.exports = plugin;
+export default plugin;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"rev-hash": "^3.0.0",
 		"rev-path": "^2.0.0",
 		"sort-keys": "^4.0.0",
-		"through2": "^3.0.1",
+		"through2": "^4.0.2",
 		"vinyl": "^2.1.0",
 		"vinyl-file": "^3.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
 		"assets"
 	],
 	"dependencies": {
+		"easy-transform-stream": "^1.0.0",
 		"modify-filename": "^2.0.0",
 		"plugin-error": "^2.0.1",
 		"rev-hash": "^4.0.0",
 		"rev-path": "^3.0.0",
 		"sort-keys": "^5.0.0",
-		"through2": "^4.0.2",
 		"vinyl": "^3.0.0",
 		"vinyl-file": "^5.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"rev-path": "^2.0.0",
 		"sort-keys": "^4.0.0",
 		"through2": "^4.0.2",
-		"vinyl": "^2.1.0",
+		"vinyl": "^3.0.0",
 		"vinyl-file": "^3.0.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=14"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=14"
+		"node": ">=16"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	],
 	"dependencies": {
 		"modify-filename": "^1.1.0",
-		"plugin-error": "^1.0.1",
+		"plugin-error": "^2.0.1",
 		"rev-hash": "^3.0.0",
 		"rev-path": "^2.0.0",
 		"sort-keys": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
 	"description": "Static asset revisioning by appending content hash to filenames: unicorn.css => unicorn-d41d8cd98f.css",
 	"license": "MIT",
 	"repository": "sindresorhus/gulp-rev",
+	"funding": "https://github.com/sponsors/sindresorhus",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
+	"type": "module",
+	"exports": "./index.js",
 	"engines": {
 		"node": ">=14"
 	},
@@ -34,19 +37,19 @@
 		"assets"
 	],
 	"dependencies": {
-		"modify-filename": "^1.1.0",
+		"modify-filename": "^2.0.0",
 		"plugin-error": "^2.0.1",
-		"rev-hash": "^3.0.0",
-		"rev-path": "^2.0.0",
-		"sort-keys": "^4.0.0",
+		"rev-hash": "^4.0.0",
+		"rev-path": "^3.0.0",
+		"sort-keys": "^5.0.0",
 		"through2": "^4.0.2",
 		"vinyl": "^3.0.0",
-		"vinyl-file": "^3.0.0"
+		"vinyl-file": "^5.0.0"
 	},
 	"devDependencies": {
-		"ava": "^2.3.0",
-		"p-event": "^4.1.0",
-		"xo": "^0.24.0"
+		"ava": "^5.1.0",
+		"p-event": "^5.0.1",
+		"xo": "^0.53.1"
 	},
 	"peerDependencies": {
 		"gulp": ">=4"

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ The hash of each rev'd file is stored at `file.revHash`. You can use this for cu
 import gulp from 'gulp';
 import rev from 'gulp-rev';
 
-export default = () => (
+export default () => (
 	// By default, Gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
 	gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
@@ -113,7 +113,7 @@ By default, `rev-manifest.json` will be replaced as a whole. To merge with an ex
 import gulp from 'gulp';
 import rev from 'gulp-rev';
 
-export default = () => (
+export default () => (
 	// By default, Gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
 	gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
@@ -135,19 +135,19 @@ You can optionally call `rev.manifest('manifest.json')` to give it a different p
 Because of the way `gulp-concat` handles file paths, you may need to set `cwd` and `path` manually on your `gulp-concat` instance to get everything to work correctly:
 
 ```js
-const gulp = require('gulp');
-const sourcemaps = require('gulp-sourcemaps');
-const concat = require('gulp-concat');
+import gulp from 'gulp';
+import rev from 'gulp-rev';
+import sourcemaps from 'gulp-sourcemaps';
+import concat from 'gulp-concat';
 
-exports.default = async () => {
-	const {default: rev} = await import('gulp-rev');
-	return gulp.src('src/*.js')
+export default () => (
+	gulp.src('src/*.js')
 		.pipe(sourcemaps.init())
 		.pipe(concat({path: 'bundle.js', cwd: ''}))
 		.pipe(rev())
 		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('dist'))
-};
+);
 ```
 
 ## Different hash for unchanged files
@@ -163,20 +163,20 @@ Since the order of streams are not guaranteed, some plugins such as `gulp-concat
 This plugin does not support streaming. If you have files from a streaming source, such as Browserify, you should use [`gulp-buffer`](https://github.com/jeromew/gulp-buffer) before `gulp-rev` in your pipeline:
 
 ```js
-const gulp = require('gulp');
-const browserify = require('browserify');
-const source = require('vinyl-source-stream');
-const buffer = require('gulp-buffer');
+import gulp from 'gulp';
+import browserify from 'browserify';
+import source from 'vinyl-source-stream';
+import buffer from 'gulp-buffer';
+import rev from 'gulp-rev';
 
-exports.default = async () => {
-	const {default: rev} = await import('gulp-rev');
-	return browserify('src/index.js')
+export default () => (
+	browserify('src/index.js')
 		.bundle({debug: true})
 		.pipe(source('index.min.js'))
 		.pipe(buffer())
 		.pipe(rev())
 		.pipe(gulp.dest('dist'))
-};
+);
 ```
 
 ## Integration

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,13 @@ $ npm install --save-dev gulp-rev
 ## Usage
 
 ```js
-import {src, dest} from 'gulp';
+import gulp from 'gulp';
 import rev from 'gulp-rev';
 
 export default () => (
-	src('src/*.css')
+	gulp.src('src/*.css')
 		.pipe(rev())
-		.pipe(dest('dist'))
+		.pipe(gulp.dest('dist'))
 );
 ```
 
@@ -83,18 +83,18 @@ The hash of each rev'd file is stored at `file.revHash`. You can use this for cu
 ### Asset manifest
 
 ```js
-import {src, dest} from 'gulp';
+import gulp from 'gulp';
 import rev from 'gulp-rev';
 
 export default = () => (
 	// By default, Gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
-	src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
-		.pipe(dest('build/assets'))  // Copy original assets to build dir
+	gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
+		.pipe(gulp.dest('build/assets'))  // Copy original assets to build dir
 		.pipe(rev())
-		.pipe(dest('build/assets'))  // Write rev'd assets to build dir
+		.pipe(gulp.dest('build/assets'))  // Write rev'd assets to build dir
 		.pipe(rev.manifest())
-		.pipe(dest('build/assets'))  // Write manifest to build dir
+		.pipe(gulp.dest('build/assets'))  // Write manifest to build dir
 );
 ```
 
@@ -110,21 +110,21 @@ An asset manifest, mapping the original paths to the revisioned paths, will be w
 By default, `rev-manifest.json` will be replaced as a whole. To merge with an existing manifest, pass `merge: true` and the output destination (as `base`) to `rev.manifest()`:
 
 ```js
-import {src, dest} from 'gulp';
+import gulp from 'gulp';
 import rev from 'gulp-rev';
 
 export default = () => (
 	// By default, Gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
-	src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
-		.pipe(dest('build/assets'))
+	gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
+		.pipe(gulp.dest('build/assets'))
 		.pipe(rev())
-		.pipe(dest('build/assets'))
+		.pipe(gulp.dest('build/assets'))
 		.pipe(rev.manifest({
 			base: 'build/assets',
 			merge: true // Merge with the existing manifest if one exists
 		}))
-		.pipe(dest('build/assets'))
+		.pipe(gulp.dest('build/assets'))
 );
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,13 @@ $ npm install --save-dev gulp-rev
 ## Usage
 
 ```js
-const gulp = require('gulp');
-const rev = require('gulp-rev');
+import {src, dest} from 'gulp';
+import rev from 'gulp-rev';
 
-exports.default = () => (
-	gulp.src('src/*.css')
+export default () => (
+	src('src/*.css')
 		.pipe(rev())
-		.pipe(gulp.dest('dist'))
+		.pipe(dest('dist'))
 );
 ```
 
@@ -83,18 +83,18 @@ The hash of each rev'd file is stored at `file.revHash`. You can use this for cu
 ### Asset manifest
 
 ```js
-const gulp = require('gulp');
-const rev = require('gulp-rev');
+import {src, dest} from 'gulp';
+import rev from 'gulp-rev';
 
-exports.default = () => (
+export default = () => (
 	// By default, Gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
-	gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
-		.pipe(gulp.dest('build/assets'))  // Copy original assets to build dir
+	src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
+		.pipe(dest('build/assets'))  // Copy original assets to build dir
 		.pipe(rev())
-		.pipe(gulp.dest('build/assets'))  // Write rev'd assets to build dir
+		.pipe(dest('build/assets'))  // Write rev'd assets to build dir
 		.pipe(rev.manifest())
-		.pipe(gulp.dest('build/assets'))  // Write manifest to build dir
+		.pipe(dest('build/assets'))  // Write manifest to build dir
 );
 ```
 
@@ -110,21 +110,21 @@ An asset manifest, mapping the original paths to the revisioned paths, will be w
 By default, `rev-manifest.json` will be replaced as a whole. To merge with an existing manifest, pass `merge: true` and the output destination (as `base`) to `rev.manifest()`:
 
 ```js
-const gulp = require('gulp');
-const rev = require('gulp-rev');
+import {src, dest} from 'gulp';
+import rev from 'gulp-rev';
 
-exports.default = () => (
+export default = () => (
 	// By default, Gulp would pick `assets/css` as the base,
 	// so we need to set it explicitly:
-	gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
-		.pipe(gulp.dest('build/assets'))
+	src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
+		.pipe(dest('build/assets'))
 		.pipe(rev())
-		.pipe(gulp.dest('build/assets'))
+		.pipe(dest('build/assets'))
 		.pipe(rev.manifest({
 			base: 'build/assets',
 			merge: true // Merge with the existing manifest if one exists
 		}))
-		.pipe(gulp.dest('build/assets'))
+		.pipe(dest('build/assets'))
 );
 ```
 
@@ -136,18 +136,18 @@ Because of the way `gulp-concat` handles file paths, you may need to set `cwd` a
 
 ```js
 const gulp = require('gulp');
-const rev = require('gulp-rev');
 const sourcemaps = require('gulp-sourcemaps');
 const concat = require('gulp-concat');
 
-exports.default = () => (
-	gulp.src('src/*.js')
+exports.default = async () => {
+	const {default: rev} = await import('gulp-rev');
+	return gulp.src('src/*.js')
 		.pipe(sourcemaps.init())
 		.pipe(concat({path: 'bundle.js', cwd: ''}))
 		.pipe(rev())
 		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('dist'))
-);
+};
 ```
 
 ## Different hash for unchanged files
@@ -167,16 +167,16 @@ const gulp = require('gulp');
 const browserify = require('browserify');
 const source = require('vinyl-source-stream');
 const buffer = require('gulp-buffer');
-const rev = require('gulp-rev');
 
-exports.default = () => (
-	browserify('src/index.js')
+exports.default = async () => {
+	const {default: rev} = await import('gulp-rev');
+	return browserify('src/index.js')
 		.bundle({debug: true})
 		.pipe(source('index.min.js'))
 		.pipe(buffer())
 		.pipe(rev())
 		.pipe(gulp.dest('dist'))
-);
+};
 ```
 
 ## Integration

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -1,3 +1,4 @@
+import {Buffer} from 'node:buffer';
 import Vinyl from 'vinyl';
 
 export default function createFile({
@@ -8,13 +9,13 @@ export default function createFile({
 	revName,
 	cwd,
 	base,
-	contents = ''
+	contents = '',
 }) {
 	const file = new Vinyl({
 		path,
 		cwd,
 		base,
-		contents: Buffer.from(contents)
+		contents: Buffer.from(contents),
 	});
 	file.revOrigPath = revOrigPath;
 	file.revOrigBase = revOrigBase;

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -1,8 +1,12 @@
-import path from 'path';
+import {Buffer} from 'node:buffer';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import test from 'ava';
-import pEvent from 'p-event';
-import rev from '..';
-import createFile from './_helper';
+import {pEvent} from 'p-event';
+import rev from '../index.js';
+import createFile from './_helper.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const manifestFixture = './test.manifest-fixture.json';
 const manifestFixturePath = path.join(__dirname, manifestFixture);
@@ -14,14 +18,14 @@ test('builds a rev manifest file', async t => {
 
 	stream.end(createFile({
 		path: 'unicorn-d41d8cd98f.css',
-		revOrigPath: 'unicorn.css'
+		revOrigPath: 'unicorn.css',
 	}));
 
 	const file = await data;
 	t.is(file.relative, 'rev-manifest.json');
 	t.deepEqual(
 		JSON.parse(file.contents.toString()),
-		{'unicorn.css': 'unicorn-d41d8cd98f.css'}
+		{'unicorn.css': 'unicorn-d41d8cd98f.css'},
 	);
 });
 
@@ -32,7 +36,7 @@ test('allows naming the manifest file', async t => {
 
 	stream.end(createFile({
 		path: 'unicorn-d41d8cd98f.css',
-		revOrigPath: 'unicorn.css'
+		revOrigPath: 'unicorn.css',
 	}));
 
 	const file = await data;
@@ -42,13 +46,13 @@ test('allows naming the manifest file', async t => {
 test('appends to an existing rev manifest file', async t => {
 	const stream = rev.manifest({
 		path: manifestFixturePath,
-		merge: true
+		merge: true,
 	});
 	const data = pEvent(stream, 'data');
 
 	stream.end(createFile({
 		path: 'unicorn-d41d8cd98f.css',
-		revOrigPath: 'unicorn.css'
+		revOrigPath: 'unicorn.css',
 	}));
 
 	const file = await data;
@@ -57,8 +61,8 @@ test('appends to an existing rev manifest file', async t => {
 		JSON.parse(file.contents.toString()),
 		{
 			'app.js': 'app-a41d8cd1.js',
-			'unicorn.css': 'unicorn-d41d8cd98f.css'
-		}
+			'unicorn.css': 'unicorn-d41d8cd98f.css',
+		},
 	);
 });
 
@@ -68,37 +72,37 @@ test('does not append to an existing rev manifest by default', async t => {
 
 	stream.end(createFile({
 		path: 'unicorn-d41d8cd98f.css',
-		revOrigPath: 'unicorn.css'
+		revOrigPath: 'unicorn.css',
 	}));
 
 	const file = await data;
 	t.is(file.relative, manifestFixtureRelative);
 	t.deepEqual(
 		JSON.parse(file.contents.toString()),
-		{'unicorn.css': 'unicorn-d41d8cd98f.css'}
+		{'unicorn.css': 'unicorn-d41d8cd98f.css'},
 	);
 });
 
 test('sorts the rev manifest keys', async t => {
 	const stream = rev.manifest({
 		path: manifestFixturePath,
-		merge: true
+		merge: true,
 	});
 	const data = pEvent(stream, 'data');
 
 	stream.write(createFile({
 		path: 'unicorn-d41d8cd98f.css',
-		revOrigPath: 'unicorn.css'
+		revOrigPath: 'unicorn.css',
 	}));
 	stream.end(createFile({
 		path: 'pony-d41d8cd98f.css',
-		revOrigPath: 'pony.css'
+		revOrigPath: 'pony.css',
 	}));
 
 	const file = await data;
 	t.deepEqual(
 		Object.keys(JSON.parse(file.contents.toString())),
-		['app.js', 'pony.css', 'unicorn.css']
+		['app.js', 'pony.css', 'unicorn.css'],
 	);
 });
 
@@ -113,7 +117,7 @@ test('respects directories', async t => {
 		revOrigPath: path.join(__dirname, 'foo', 'unicorn.css'),
 		revOrigBase: __dirname,
 		origName: 'unicorn.css',
-		revName: 'unicorn-d41d8cd98f.css'
+		revName: 'unicorn-d41d8cd98f.css',
 	}));
 	stream.end(createFile({
 		cwd: __dirname,
@@ -122,7 +126,7 @@ test('respects directories', async t => {
 		revOrigBase: __dirname,
 		revOrigPath: path.join(__dirname, 'bar', 'pony.css'),
 		origName: 'pony.css',
-		revName: 'pony-d41d8cd98f.css'
+		revName: 'pony-d41d8cd98f.css',
 	}));
 
 	const MANIFEST = {};
@@ -146,7 +150,7 @@ test('respects files coming from directories with different bases', async t => {
 		revOrigBase: path.join(__dirname, 'vendor1'),
 		revOrigPath: path.join(__dirname, 'vendor1', 'foo', 'scriptfoo.js'),
 		origName: 'scriptfoo.js',
-		revName: 'scriptfoo-d41d8cd98f.js'
+		revName: 'scriptfoo-d41d8cd98f.js',
 	}));
 	stream.end(createFile({
 		cwd: __dirname,
@@ -155,7 +159,7 @@ test('respects files coming from directories with different bases', async t => {
 		revOrigBase: path.join(__dirname, 'vendor2'),
 		revOrigPath: path.join(__dirname, 'vendor2', 'bar', 'scriptbar.js'),
 		origName: 'scriptfoo.js',
-		revName: 'scriptfoo-d41d8cd98f.js'
+		revName: 'scriptfoo-d41d8cd98f.js',
 	}));
 
 	const MANIFEST = {};
@@ -175,13 +179,13 @@ test('uses correct base path for each file', async t => {
 		cwd: 'app/',
 		base: 'app/',
 		path: path.join('app', 'foo', 'scriptfoo-d41d8cd98f.js'),
-		revOrigPath: 'scriptfoo.js'
+		revOrigPath: 'scriptfoo.js',
 	}));
 	stream.end(createFile({
 		cwd: '/',
 		base: 'assets/',
 		path: path.join('/assets', 'bar', 'scriptbar-d41d8cd98f.js'),
-		revOrigPath: 'scriptbar.js'
+		revOrigPath: 'scriptbar.js',
 	}));
 
 	const MANIFEST = {};

--- a/test/rev.js
+++ b/test/rev.js
@@ -59,11 +59,15 @@ test('handles sourcemaps transparently', async t => {
 		contents: JSON.stringify({file: 'pastissada.css'}),
 	}));
 
+	let sourcemapCount = 0;
 	for await (const file of data) {
 		if (path.extname(file.path) === '.map') {
 			t.is(file.path, path.normalize('maps/pastissada-d41d8cd98f.css.map'));
+			sourcemapCount++;
 		}
 	}
+
+	t.is(sourcemapCount, 1);
 });
 
 test('handles unparseable sourcemaps correctly', async t => {
@@ -81,11 +85,15 @@ test('handles unparseable sourcemaps correctly', async t => {
 		contents: 'Wait a minute, this is invalid JSON!',
 	}));
 
+	let sourcemapCount = 0;
 	for await (const file of data) {
 		if (path.extname(file.path) === '.map') {
 			t.is(file.path, 'pastissada-d41d8cd98f.css.map');
+			sourcemapCount++;
 		}
 	}
+
+	t.is(sourcemapCount, 1);
 });
 
 test('okay when the optional sourcemap.file is not defined', async t => {
@@ -103,11 +111,15 @@ test('okay when the optional sourcemap.file is not defined', async t => {
 		contents: JSON.stringify({}),
 	}));
 
+	let sourcemapCount = 0;
 	for await (const file of data) {
 		if (path.extname(file.path) === '.map') {
 			t.is(file.path, 'pastissada-d41d8cd98f.css.map');
+			sourcemapCount++;
 		}
 	}
+
+	t.is(sourcemapCount, 1);
 });
 
 test('handles a `.` in the folder name', async t => {


### PR DESCRIPTION
Thanks for releasing a [new version](https://github.com/sindresorhus/vinyl-file/releases/tag/v5.0.0) of `vinyl-file` 🙏 This time, I want to update `gulp-rev`!

### What's new?

- Update all dependencies
- Migrate to ESM
- Migrate async `ava` tests using `p-event`
- Fix linting errors with new `xo`

[The tests are passing in my repo](https://github.com/pioug/gulp-rev/actions). 

I also updated some examples in the readme but I am not too sure about the ones that mix ESM and CJS modules. 